### PR TITLE
fix: change build_size column type to bigint in analysis and master_image entities

### DIFF
--- a/packages/server-core/src/database/domains/analysis/entity.ts
+++ b/packages/server-core/src/database/domains/analysis/entity.ts
@@ -114,7 +114,7 @@ export class AnalysisEntity implements Analysis {
         build_os: string | null;
 
     @Column({
-        type: 'int', unsigned: true, nullable: true, default: null,
+        type: 'bigint', unsigned: true, nullable: true, default: null,
     })
         build_size: number | null;
 

--- a/packages/server-core/src/database/domains/master-image/entity.ts
+++ b/packages/server-core/src/database/domains/master-image/entity.ts
@@ -44,7 +44,7 @@ export class MasterImageEntity implements MasterImage {
         build_hash: string | null;
 
     @Column({
-        type: 'int', unsigned: true, nullable: true, default: null,
+        type: 'bigint', unsigned: true, nullable: true, default: null,
     })
         build_size: number | null;
 

--- a/packages/server-core/src/database/migrations/mysql/1775822138823-Default.ts
+++ b/packages/server-core/src/database/migrations/mysql/1775822138823-Default.ts
@@ -1,0 +1,23 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Default1775822138823 implements MigrationInterface {
+    name = 'Default1775822138823';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`master_images\` MODIFY COLUMN \`build_size\` bigint UNSIGNED NULL
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`analysis_entity\` MODIFY COLUMN \`build_size\` bigint UNSIGNED NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`analysis_entity\` MODIFY COLUMN \`build_size\` int UNSIGNED NULL
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`master_images\` MODIFY COLUMN \`build_size\` int UNSIGNED NULL
+        `);
+    }
+}

--- a/packages/server-core/src/database/migrations/postgres/1775822138823-Default.ts
+++ b/packages/server-core/src/database/migrations/postgres/1775822138823-Default.ts
@@ -1,0 +1,23 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Default1775822138823 implements MigrationInterface {
+    name = 'Default1775822138823';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "master_images" ALTER COLUMN "build_size" TYPE bigint
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "analysis_entity" ALTER COLUMN "build_size" TYPE bigint
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "analysis_entity" ALTER COLUMN "build_size" TYPE integer
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "master_images" ALTER COLUMN "build_size" TYPE integer
+        `);
+    }
+}


### PR DESCRIPTION
**Entity files updated** (type: int → bigint):
   - `packages/server-core/src/database/domains/analysis/entity.ts`
   - `packages/server-core/src/database/domains/master-image/entity.ts`

2. **Migrations:**
   - `packages/server-core/src/database/migrations/postgres/1775822138823-Default.ts`
   - `packages/server-core/src/database/migrations/mysql/1775822138823-Default.ts`
   - tested on postgres and mysql in docker-compose.yaml



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to support larger build sizes in build tracking across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->