### PR TITLE
feat(server-core): call metadata recalculator on analysis create

### DIFF
--- a/apps/server-core/src/core/entities/analysis/service.ts
+++ b/apps/server-core/src/core/entities/analysis/service.ts
@@ -109,6 +109,8 @@ export class AnalysisService extends AbstractEntityService implements IAnalysisS
 
         await this.repository.save(entity, { data: actor.metadata });
 
+        await this.recalculator.recalcDebounced(entity.id);
+
         await this.storageManager.check(entity);
 
         entity.project.analyses++;

--- a/apps/server-core/test/unit/core/entities/analysis/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/analysis/service.spec.ts
@@ -176,6 +176,26 @@ describe('AnalysisService', () => {
             expect(result.id).toBeDefined();
             expect(taskManager.getCallCount()).toBeGreaterThan(0);
         });
+
+        it('should call recalcDebounced after save', async () => {
+            const project = createTestProject({ master_image_id: randomUUID() });
+            projectRepository.seed(project);
+
+            const origValidate = analysisRepository.validateJoinColumns.bind(analysisRepository);
+            analysisRepository.validateJoinColumns = async (data: Partial<Analysis>) => {
+                await origValidate(data);
+                data.project = project;
+            };
+
+            const result = await service.create(
+                { name: 'test-analysis', project_id: project.id },
+                createAllowAllActor(),
+            );
+
+            expect(result.id).toBeDefined();
+            expect(analysisRecalculator.getDebouncedCallCount()).toBe(1);
+            expect(analysisRecalculator.getDebouncedCalls()[0]).toBe(result.id);
+        });
     });
 
     describe('update', () => {


### PR DESCRIPTION
closes #1567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analysis metadata now automatically recalculates when new analyses are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->