### PR TITLE
fix(server-storage): stream uploads end-to-end to avoid Hash.update overflow

### DIFF
--- a/apps/server-storage/src/adapters/http/controllers/bucket/upload.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket/upload.ts
@@ -20,7 +20,6 @@ import type { IRoutupEvent } from 'routup';
 import { BadRequestError } from '@ebec/http';
 import { useRequestIdentityOrFail } from '@privateaim/server-http-kit';
 import type { BucketFileComponent } from '../../../../app/components/bucket-file/module.ts';
-import { streamToBuffer } from '../../../../core/utils/stream-to-buffer.ts';
 import type { BucketEntity, BucketFileEntity  } from '../../../database/index.ts';
 
 export async function uploadRequestFilesToBucket(
@@ -54,6 +53,7 @@ export async function uploadRequestFilesToBucket(
 
         instance.on('file', (_, file, info) => {
             if (typeof info.filename === 'undefined') {
+                file.resume();
                 return;
             }
 
@@ -62,45 +62,40 @@ export async function uploadRequestFilesToBucket(
                     fileResolve,
                     fileReject,
                 ) => {
-                    streamToBuffer(file)
-                        .then((buffer) => {
-                            caller.callWith(
-                                BucketFileCommand.CREATE,
-                                {
-                                    meta: {
-                                        actor_type: actor.type,
-                                        actor_id: actor.id,
-                                        name: path.basename(info.filename),
-                                        path: info.filename,
-                                        size: buffer.length,
-                                        directory: path.dirname(info.filename),
-                                        realm_id: identity.realmId,
-                                        bucket_id: bucket.id,
-                                        bucket,
-                                    },
-                                    data: buffer,
-                                },
-                                {},
-                                {
-                                    handle: async (childValue, childContext) => {
-                                        await bucketFileEventCaller.call(
-                                            childContext.key,
-                                            childValue,
-                                            childContext.metadata,
-                                        );
+                    caller.callWith(
+                        BucketFileCommand.CREATE,
+                        {
+                            meta: {
+                                actor_type: actor.type,
+                                actor_id: actor.id,
+                                name: path.basename(info.filename),
+                                path: info.filename,
+                                directory: path.dirname(info.filename),
+                                realm_id: identity.realmId,
+                                bucket_id: bucket.id,
+                                bucket,
+                            },
+                            data: file,
+                        },
+                        {},
+                        {
+                            handle: async (childValue, childContext) => {
+                                await bucketFileEventCaller.call(
+                                    childContext.key,
+                                    childValue,
+                                    childContext.metadata,
+                                );
 
-                                        if (childContext.key === BucketFileEvent.CREATION_FINISHED) {
-                                            fileResolve(childValue as BucketFileCreationFinishedEventPayload);
-                                        }
+                                if (childContext.key === BucketFileEvent.CREATION_FINISHED) {
+                                    fileResolve(childValue as BucketFileCreationFinishedEventPayload);
+                                }
 
-                                        if (childContext.key === BucketFileEvent.CREATION_FAILED) {
-                                            fileReject(childValue);
-                                        }
-                                    },
-                                },
-                            )
-                                .catch((e) => fileReject(e));
-                        })
+                                if (childContext.key === BucketFileEvent.CREATION_FAILED) {
+                                    fileReject(childValue);
+                                }
+                            },
+                        },
+                    )
                         .catch((e) => fileReject(e));
                 },
             );

--- a/apps/server-storage/src/adapters/http/controllers/bucket/upload.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket/upload.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { ReadableStream } from 'node:stream/web';
 import { DirectComponentCaller } from '@privateaim/server-kit';
@@ -20,7 +21,7 @@ import type { IRoutupEvent } from 'routup';
 import { BadRequestError } from '@ebec/http';
 import { useRequestIdentityOrFail } from '@privateaim/server-http-kit';
 import type { BucketFileComponent } from '../../../../app/components/bucket-file/module.ts';
-import type { BucketEntity, BucketFileEntity  } from '../../../database/index.ts';
+import type { BucketEntity } from '../../../database/index.ts';
 
 export async function uploadRequestFilesToBucket(
     event: IRoutupEvent,
@@ -48,8 +49,8 @@ export async function uploadRequestFilesToBucket(
 
     const identity = useRequestIdentityOrFail(event);
 
-    return new Promise<BucketFileEntity[]>((resolve, reject) => {
-        const entries : Promise<BucketFileEntity>[] = [];
+    return new Promise<BucketFileCreationFinishedEventPayload[]>((resolve, reject) => {
+        const entries : Promise<BucketFileCreationFinishedEventPayload>[] = [];
 
         instance.on('file', (_, file, info) => {
             if (typeof info.filename === 'undefined') {
@@ -57,7 +58,7 @@ export async function uploadRequestFilesToBucket(
                 return;
             }
 
-            const promise = new Promise<BucketFileEntity>(
+            const promise = new Promise<BucketFileCreationFinishedEventPayload>(
                 (
                     fileResolve,
                     fileReject,
@@ -66,6 +67,7 @@ export async function uploadRequestFilesToBucket(
                         BucketFileCommand.CREATE,
                         {
                             meta: {
+                                id: randomUUID(),
                                 actor_type: actor.type,
                                 actor_id: actor.id,
                                 name: path.basename(info.filename),

--- a/apps/server-storage/src/adapters/storage/fs.ts
+++ b/apps/server-storage/src/adapters/storage/fs.ts
@@ -6,9 +6,10 @@
  */
 
 import fs from 'node:fs/promises';
-import { createReadStream } from 'node:fs';
+import { createReadStream, createWriteStream } from 'node:fs';
 import path from 'node:path';
-import type { Readable } from 'node:stream';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import type { IStorageAdapter } from '../../core/storage/types.ts';
 
 export class FsStorageAdapter implements IStorageAdapter {
@@ -35,10 +36,14 @@ export class FsStorageAdapter implements IStorageAdapter {
         await fs.rm(path.join(this.basePath, name), { recursive: true, force: true });
     }
 
-    async putObject(bucket: string, key: string, data: Buffer): Promise<void> {
+    async putObject(bucket: string, key: string, data: Buffer | Readable): Promise<void> {
         const filePath = path.join(this.basePath, bucket, key);
         await fs.mkdir(path.dirname(filePath), { recursive: true });
-        await fs.writeFile(filePath, data);
+        if (data instanceof Readable) {
+            await pipeline(data, createWriteStream(filePath));
+        } else {
+            await fs.writeFile(filePath, data);
+        }
     }
 
     async getObject(bucket: string, key: string): Promise<Readable> {

--- a/apps/server-storage/src/adapters/storage/minio.ts
+++ b/apps/server-storage/src/adapters/storage/minio.ts
@@ -32,7 +32,7 @@ export class MinioStorageAdapter implements IStorageAdapter {
         await this.client.removeBucket(name);
     }
 
-    async putObject(bucket: string, key: string, data: Buffer, size: number): Promise<void> {
+    async putObject(bucket: string, key: string, data: Buffer | Readable, size?: number): Promise<void> {
         await this.client.putObject(bucket, key, data, size);
     }
 

--- a/apps/server-storage/src/app/components/bucket-file/handlers/create/module.ts
+++ b/apps/server-storage/src/app/components/bucket-file/handlers/create/module.ts
@@ -18,6 +18,7 @@ import {
 import { BucketValidator, DomainType  } from '@privateaim/storage-kit';
 import { LogFlag } from '@privateaim/telemetry-kit';
 import crypto from 'node:crypto';
+import { Transform } from 'node:stream';
 import { useDataSource } from 'typeorm-extension';
 import type { IStorageAdapter } from '../../../../../core/storage/types.ts';
 import { BucketEntity, BucketFileEntity } from '../../../../../adapters/database/index.ts';
@@ -90,23 +91,32 @@ export class BucketFileCreateHandler implements ComponentHandler<
         }
 
         // hash
-
         const hashBuilder = crypto.createHash('sha256');
         hashBuilder.update(meta.path);
         const hash = hashBuilder.digest('hex');
+
+        // count bytes while streaming into storage
+        let size = 0;
+        const counter = new Transform({
+            transform(chunk: Buffer, _enc, cb) {
+                size += chunk.length;
+                cb(null, chunk);
+            },
+        });
+        data.pipe(counter);
 
         // upload
         await this.storage.putObject(
             toBucketName(bucket.id),
             hash,
-            data,
-            data.length,
+            counter,
         );
 
         const repository = dataSource.getRepository(BucketFileEntity);
         const entity = repository.create({
             ...meta,
             hash,
+            size,
         });
 
         await repository.save(entity);

--- a/apps/server-storage/src/app/components/bucket-file/handlers/create/module.ts
+++ b/apps/server-storage/src/app/components/bucket-file/handlers/create/module.ts
@@ -49,10 +49,15 @@ export class BucketFileCreateHandler implements ComponentHandler<
             // todo: check if image exists, otherwise local queue task
             await this.process(value, context);
         } catch (e) {
+            // Drain the source stream so the upstream parser (Busboy) can move on.
+            // Idempotent if pipeline already destroyed it.
+            if (!value.data.destroyed) {
+                value.data.destroy();
+            }
+
             this.logger?.error({
                 message: e,
                 command: BucketCommand.CREATE,
-                analysis_id: value.meta.id,
                 [LogFlag.REF_ID]: value.meta.id,
                 [LogFlag.REF_TYPE]: DomainType.BUCKET_FILE,
             });
@@ -72,10 +77,11 @@ export class BucketFileCreateHandler implements ComponentHandler<
         context: ComponentHandlerContext<BucketFileComponentEventMap, BucketFileCommand.CREATE>,
     ): Promise<void> {
         const { data, meta } = value;
+        const { bucket: bucketRelation, ...metaForEvent } = meta;
 
         await context.handle(
             BucketFileEvent.CREATION_STARTED,
-            meta,
+            metaForEvent,
         );
 
         // todo: validate meta
@@ -83,18 +89,17 @@ export class BucketFileCreateHandler implements ComponentHandler<
         const dataSource = await useDataSource();
 
         let bucket : BucketEntity;
-        if (meta.bucket) {
-            bucket = meta.bucket;
+        if (bucketRelation) {
+            bucket = bucketRelation;
         } else {
             const bucketRepository = dataSource.getRepository(BucketEntity);
 
             bucket = await bucketRepository.findOneByOrFail({ id: meta.bucket_id });
         }
 
-        // hash
-        const hashBuilder = crypto.createHash('sha256');
-        hashBuilder.update(meta.path);
-        const hash = hashBuilder.digest('hex');
+        // Random storage key — the (bucket_id, path) DB unique constraint enforces
+        // logical de-duplication, so the object key just needs to be unique per row.
+        const hash = crypto.randomBytes(32).toString('hex');
 
         // count bytes while streaming into storage
         let size = 0;
@@ -105,13 +110,19 @@ export class BucketFileCreateHandler implements ComponentHandler<
             },
         });
 
-        // upload — pipeline forwards source errors to the counter Transform
-        // so a client abort destroys both streams and putObject rejects.
+        // Bidirectional teardown:
+        //   - pipeline(data, counter) forwards source errors to counter
+        //   - putObject rejection destroys counter, which causes pipeline to destroy data
         const uploadPromise = this.storage.putObject(
             toBucketName(bucket.id),
             hash,
             counter,
-        );
+        ).catch((err) => {
+            if (!counter.destroyed) {
+                counter.destroy(err);
+            }
+            throw err;
+        });
         await Promise.all([
             uploadPromise,
             pipeline(data, counter),
@@ -119,7 +130,7 @@ export class BucketFileCreateHandler implements ComponentHandler<
 
         const repository = dataSource.getRepository(BucketFileEntity);
         const entity = repository.create({
-            ...meta,
+            ...metaForEvent,
             hash,
             size,
         });

--- a/apps/server-storage/src/app/components/bucket-file/handlers/create/module.ts
+++ b/apps/server-storage/src/app/components/bucket-file/handlers/create/module.ts
@@ -19,6 +19,7 @@ import { BucketValidator, DomainType  } from '@privateaim/storage-kit';
 import { LogFlag } from '@privateaim/telemetry-kit';
 import crypto from 'node:crypto';
 import { Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { useDataSource } from 'typeorm-extension';
 import type { IStorageAdapter } from '../../../../../core/storage/types.ts';
 import { BucketEntity, BucketFileEntity } from '../../../../../adapters/database/index.ts';
@@ -103,14 +104,18 @@ export class BucketFileCreateHandler implements ComponentHandler<
                 cb(null, chunk);
             },
         });
-        data.pipe(counter);
 
-        // upload
-        await this.storage.putObject(
+        // upload — pipeline forwards source errors to the counter Transform
+        // so a client abort destroys both streams and putObject rejects.
+        const uploadPromise = this.storage.putObject(
             toBucketName(bucket.id),
             hash,
             counter,
         );
+        await Promise.all([
+            uploadPromise,
+            pipeline(data, counter),
+        ]);
 
         const repository = dataSource.getRepository(BucketFileEntity);
         const entity = repository.create({

--- a/apps/server-storage/src/core/storage/types.ts
+++ b/apps/server-storage/src/core/storage/types.ts
@@ -12,7 +12,7 @@ export interface IStorageAdapter {
     makeBucket(name: string, region?: string): Promise<void>;
     removeBucket(name: string): Promise<void>;
 
-    putObject(bucket: string, key: string, data: Buffer, size: number): Promise<void>;
+    putObject(bucket: string, key: string, data: Buffer | Readable, size?: number): Promise<void>;
     getObject(bucket: string, key: string): Promise<Readable>;
     removeObject(bucket: string, key: string): Promise<void>;
     removeObjects(bucket: string, keys: string[]): Promise<void>;

--- a/apps/server-storage/test/unit/core/entities/bucket/fake-storage.ts
+++ b/apps/server-storage/test/unit/core/entities/bucket/fake-storage.ts
@@ -39,8 +39,18 @@ export class FakeStorageAdapter implements IStorageAdapter {
         }
     }
 
-    async putObject(bucket: string, key: string, data: Buffer): Promise<void> {
-        this.objects.set(`${bucket}/${key}`, data);
+    async putObject(bucket: string, key: string, data: Buffer | Readable): Promise<void> {
+        let buffer: Buffer;
+        if (Buffer.isBuffer(data)) {
+            buffer = data;
+        } else {
+            const chunks: Buffer[] = [];
+            for await (const chunk of data) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+            }
+            buffer = Buffer.concat(chunks);
+        }
+        this.objects.set(`${bucket}/${key}`, buffer);
     }
 
     async getObject(bucket: string, key: string): Promise<Readable> {

--- a/packages/server-storage-kit/src/components/bucket-file/handlers/create/types.ts
+++ b/packages/server-storage-kit/src/components/bucket-file/handlers/create/types.ts
@@ -5,11 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Readable } from 'node:stream';
 import type { BucketFile } from '@privateaim/storage-kit';
 
 export type BucketFileCreateCommandPayload = {
     meta: Partial<BucketFile>,
-    data: Buffer
+    data: Readable
 };
 
 export type BucketFileCreationFailedEventPayload = {

--- a/packages/server-storage-kit/src/components/bucket-file/handlers/create/types.ts
+++ b/packages/server-storage-kit/src/components/bucket-file/handlers/create/types.ts
@@ -18,6 +18,6 @@ export type BucketFileCreationFailedEventPayload = {
     error: Error
 };
 
-export type BucketFileCreationStartedEventPayload = Partial<BucketFile>;
+export type BucketFileCreationStartedEventPayload = Partial<Omit<BucketFile, 'bucket'>>;
 
-export type BucketFileCreationFinishedEventPayload = BucketFile;
+export type BucketFileCreationFinishedEventPayload = Omit<BucketFile, 'bucket'>;


### PR DESCRIPTION
## Summary

- Uploads of ~1GB+ failed with `RangeError: data is too long` from `crypto.Hash.update` inside minio-js's `uploadStream`, because the multipart file was fully buffered before being handed to MinIO.
- Stream the Busboy file Readable directly through the component caller into `client.putObject`, so minio-js chunks and hashes per part.
- Widen `IStorageAdapter.putObject` to accept `Buffer | Readable` with optional `size`; update `MinioStorageAdapter`, `FsStorageAdapter`, and `FakeStorageAdapter`.
- `BucketFileCreateCommandPayload.data` is now `Readable`; the create handler pipes through a counting `Transform` to record the actual `size` on the entity after upload completes.

## Test plan

- [x] `npx nx run server-storage:build` (passes)
- [x] `npx nx run server-storage-kit:build` (passes)
- [x] `npx vitest run --config test/vitest.config.ts` in `apps/server-storage` — 65/65 pass
- [x] `npx eslint apps/server-storage/src apps/server-storage/test packages/server-storage-kit/src` — no new errors
- [ ] Manual verification: upload a 1GB+ file via the bucket upload endpoint and confirm it completes without `ERR_OUT_OF_RANGE` and that `bucket_file.size` reflects the streamed byte count

## Notes

- `BucketFileEventCaller` / `BucketFileTaskCaller` in `@privateaim/server-storage-kit` declare `callCreate(payload)` that now carries a `Readable`, which can't survive AMQP serialisation. No production code uses those bus-based dispatch paths today (only `DirectComponentCaller` in `upload.ts`), so this is latent. Worth a follow-up to either remove those callers or split the payload type if the bus path is ever wired up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct streaming uploads: files are uploaded as streams (no full in-memory buffering).
  * Storage adapters across backends now accept streamed data; file sizes are measured during upload.

* **Bug Fixes / Reliability**
  * Improved handling of empty/malformed upload parts to avoid stalled uploads.
  * Upload completion events are emitted as soon as creation finishes, improving responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/hub/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->