### PR TITLE
fix(server-storage): stream packFile entries via pipeline

### DIFF
--- a/apps/server-storage/src/adapters/http/controllers/bucket/stream.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket/stream.ts
@@ -6,11 +6,11 @@
  */
 
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import type { Logger } from '@privateaim/server-kit';
 import type { Pack } from 'tar-stream';
 import tar from 'tar-stream';
 import type { IStorageAdapter } from '../../../../core/storage/types.ts';
-import { streamToBuffer } from '../../../../core/utils/stream-to-buffer.ts';
 import type { BucketFileEntity } from '../../../database/entities/bucket-file.ts';
 
 async function packFile(
@@ -20,23 +20,18 @@ async function packFile(
     storage: IStorageAdapter,
     logger?: Logger,
 ) : Promise<void> {
-    const stream = await storage.getObject(name, file.hash);
-    const data = await streamToBuffer(stream);
+    if (file.size === null) {
+        throw new Error(`Cannot pack bucket file ${file.id}: size is not recorded.`);
+    }
 
     logger?.debug(`Packing file ${file.path} (${file.id})`);
 
-    return new Promise<void>((resolve, reject) => {
-        pack.entry({
-            name: file.path,
-            size: data.byteLength,
-        }, data, (err) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve();
-        });
+    const source = await storage.getObject(name, file.hash);
+    const entry = pack.entry({
+        name: file.path,
+        size: file.size,
     });
+    await pipeline(source, entry);
 }
 
 export function packBucketFiles(
@@ -54,7 +49,7 @@ export function packBucketFiles(
 
     promise
         .then(() => pack.finalize())
-        .catch(() => pack.destroy());
+        .catch((err) => pack.destroy(err));
 
     // tar-stream's Pack doesn't set readableHighWaterMark which
     // Readable.toWeb() requires. Pipe through a wrapper that has it.

--- a/apps/server-storage/src/adapters/http/controllers/bucket/stream.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket/stream.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { Readable } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { Logger } from '@privateaim/server-kit';
 import type { Pack } from 'tar-stream';
@@ -51,12 +51,15 @@ export function packBucketFiles(
         .then(() => pack.finalize())
         .catch((err) => pack.destroy(err));
 
-    // tar-stream's Pack doesn't set readableHighWaterMark which
-    // Readable.toWeb() requires. Pipe through a wrapper that has it.
-    const readable = new Readable({ highWaterMark: 16384, read() {} });
-    pack.on('data', (chunk: Buffer) => readable.push(chunk));
-    pack.on('end', () => readable.push(null));
-    pack.on('error', (err: Error) => readable.destroy(err));
+    // tar-stream's Pack doesn't expose readableHighWaterMark, which
+    // Readable.toWeb requires. Bridge through a PassThrough so pipeline can
+    // forward backpressure end-to-end (slow HTTP consumer -> web stream ->
+    // PassThrough -> pack -> packFile pipeline -> MinIO source) and
+    // propagate errors in both directions.
+    const wrapper = new PassThrough({ highWaterMark: 16384 });
+    pipeline(pack, wrapper).catch(() => {
+        // error already surfaces via wrapper destruction
+    });
 
-    return Readable.toWeb(readable) as ReadableStream;
+    return Readable.toWeb(wrapper) as ReadableStream;
 }


### PR DESCRIPTION
## Summary

- Drop `streamToBuffer` from `packFile` so the bucket tar archive endpoint (`GET /buckets/:id/stream`) no longer materialises each file into memory before writing it to the pack stream. Source flows directly from MinIO into tar-stream's per-entry Writable via `stream.pipeline`.
- tar headers require the entry size before the bytes, so we use `BucketFileEntity.size`. For now: throw if `size` is `null` (legacy rows). Follow-up will make the column NOT NULL.
- Propagate the underlying error through `pack.destroy(err)` (previously `pack.destroy()` with no arg, which silently swallowed failures and produced truncated-but-status-200 tars).

## Test plan

- [x] `npx nx run server-storage:build`
- [x] Full server-storage test suite (65/65 pass)
- [x] Specifically `GET /buckets/:id/stream` tests in `test/unit/http/bucket.spec.ts` — verify Content-Disposition, Content-Type, and non-empty body
- [x] `test/unit/bucket-file.spec.ts` pipes the tar response through `tar.extract` and counts entries — any header/size mismatch would surface as a parse error
- [ ] Manual check: stream a bucket containing a large file and verify the archive opens cleanly with `tar -tf` and `tar -xf`

## Follow-up

Make `bucket_files.size` `NOT NULL` (migration + entity + kit interface). Tracked as part of the wider clean-up; the `throw` here is the interim safety net.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved memory efficiency by eliminating unnecessary buffering during file packing operations
* Enhanced error handling and backpressure management for streaming operations
* Files missing required size metadata are now properly rejected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/hub/pull/1618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->