### PR TITLE
ci: exercise migrations against MySQL and PostgreSQL

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -231,3 +231,29 @@ Existing fakes to reuse:
 - `FakeAnalysisMetadataRecalculator` / `FakeAnalysisNodeMetadataRecalculator` / `FakeAnalysisFileMetadataRecalculator` — record `recalc()` and `recalcDebounced()` calls
 
 When a dependency has no fake yet, create one in the entity's test directory (`test/unit/core/entities/<entity>/`) implementing the port interface.
+
+## Migration Tests
+
+The `test` CI job runs the integration suite against MySQL, Postgres, and SQLite, but the schema is built via `dataSource.synchronize()` (see `apps/<service>/test/app/database.ts`) — migration files in `apps/<service>/src/adapters/database/migrations/{mysql,postgres}/` are **not** exercised by that suite.
+
+A separate `tests-migrations` CI job runs the migration CLI end-to-end for `server-core`, `server-storage`, and `server-telemetry` against a fresh MySQL and Postgres container:
+
+1. `migration run` — applies all migrations forward
+2. `migration revert` × N — undoes every migration in reverse order (verifies every `down()` works)
+3. `migration run` — re-applies the full chain (verifies idempotency)
+
+This catches SQL syntax errors, cross-DB type mismatches, and `down()` regressions across every migration. It does **not** catch data-correctness bugs in `UPDATE`/`INSERT` migrations against pre-existing rows — those still require manual smoke-testing against a populated database.
+
+The job pre-flights with a sanity check that the compiled migrations exist under `apps/<service>/dist/adapters/database/migrations/{mysql,postgres}/` — without this guard, running the CLI from the wrong working directory results in typeorm silently reporting "No migrations are pending" with exit code 0, masking the failure.
+
+Locally, run the same flow with a running compose stack:
+
+```bash
+docker compose up -d mysql        # or: postgres
+cd apps/server-core               # or: server-storage / server-telemetry
+
+DB_TYPE=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_USERNAME=root DB_PASSWORD=start123 DB_DATABASE=app \
+    node dist/cli/index.mjs migration run
+```
+
+The CLI auto-creates the target database if it does not exist.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -246,14 +246,32 @@ This catches SQL syntax errors, cross-DB type mismatches, and `down()` regressio
 
 The job pre-flights with a sanity check that the compiled migrations exist under `apps/<service>/dist/adapters/database/migrations/{mysql,postgres}/` — without this guard, running the CLI from the wrong working directory results in typeorm silently reporting "No migrations are pending" with exit code 0, masking the failure.
 
-Locally, run the same flow with a running compose stack:
+Locally, run the same `run → revert × N → run` flow against a running compose stack:
 
 ```bash
-docker compose up -d mysql        # or: postgres
+# MySQL
+docker compose up -d mysql
 cd apps/server-core               # or: server-storage / server-telemetry
 
-DB_TYPE=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_USERNAME=root DB_PASSWORD=start123 DB_DATABASE=app \
-    node dist/cli/index.mjs migration run
+export DB_TYPE=mysql DB_HOST=127.0.0.1 DB_PORT=3306 \
+       DB_USERNAME=root DB_PASSWORD=start123 DB_DATABASE=app
+
+node dist/cli/index.mjs migration run
+node dist/cli/index.mjs migration revert    # repeat once per migration
+node dist/cli/index.mjs migration run       # idempotency replay
+```
+
+```bash
+# Postgres
+docker compose up -d postgres
+cd apps/server-core
+
+export DB_TYPE=postgres DB_HOST=127.0.0.1 DB_PORT=5432 \
+       DB_USERNAME=postgres DB_PASSWORD=start123 DB_DATABASE=app
+
+node dist/cli/index.mjs migration run
+node dist/cli/index.mjs migration revert
+node dist/cli/index.mjs migration run
 ```
 
 The CLI auto-creates the target database if it does not exist.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,82 @@ jobs:
                 run: |
                     npm run test
 
+    tests-migrations:
+        name: Test Migrations
+        needs: [build]
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                service: [ server-core, server-storage, server-telemetry ]
+                db: [ mysql, postgres ]
+                include:
+                    -   db: mysql
+                        port: 3306
+                        user: root
+                    -   db: postgres
+                        port: 5432
+                        user: postgres
+
+        env:
+            DB_TYPE: ${{ matrix.db }}
+            DB_HOST: 127.0.0.1
+            DB_PORT: ${{ matrix.port }}
+            DB_USERNAME: ${{ matrix.user }}
+            DB_PASSWORD: start123
+            DB_DATABASE: app
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v6
+
+            -   name: Install
+                uses: ./.github/actions/install
+                with:
+                    node-version: ${{ env.NODE_VERSION }}
+                    node-registry: ${{ env.NODE_REGISTRY }}
+
+            -   name: Build
+                uses: ./.github/actions/build
+
+            -   name: Verify compiled migrations exist
+                working-directory: apps/${{ matrix.service }}
+                run: |
+                    count=$(ls dist/adapters/database/migrations/${{ matrix.db }}/*.mjs 2>/dev/null | wc -l | tr -d ' ')
+                    if [ "$count" = "0" ]; then
+                        echo "ERROR: no compiled migrations in apps/${{ matrix.service }}/dist/adapters/database/migrations/${{ matrix.db }}/"
+                        exit 1
+                    fi
+                    echo "Found $count migration(s)"
+                    echo "MIGRATION_COUNT=$count" >> "$GITHUB_ENV"
+
+            -   name: Start ${{ matrix.db }}
+                run: docker compose up -d ${{ matrix.db }}
+
+            -   name: Wait for ${{ matrix.db }} to be ready
+                run: |
+                    if [ "${{ matrix.db }}" = "mysql" ]; then
+                        timeout 120 bash -c 'until docker compose exec -T mysql mysqladmin ping -h127.0.0.1 --silent; do sleep 2; done'
+                    else
+                        timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
+                    fi
+
+            -   name: Run migrations forward
+                working-directory: apps/${{ matrix.service }}
+                run: node dist/cli/index.mjs migration run
+
+            -   name: Revert all migrations
+                working-directory: apps/${{ matrix.service }}
+                run: |
+                    for ((i = 1; i <= MIGRATION_COUNT; i++)); do
+                        node dist/cli/index.mjs migration revert
+                    done
+
+            -   name: Re-apply all migrations (idempotency)
+                working-directory: apps/${{ matrix.service }}
+                run: node dist/cli/index.mjs migration run
+
     lint:
         needs: [build]
         runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,7 @@ jobs:
             -   name: Wait for ${{ matrix.db }} to be ready
                 run: |
                     if [ "${{ matrix.db }}" = "mysql" ]; then
-                        timeout 120 bash -c 'until docker compose exec -T mysql mysqladmin ping -h127.0.0.1 --silent; do sleep 2; done'
+                        timeout 120 bash -c 'until docker compose exec -T mysql mysqladmin ping -h127.0.0.1 -uroot -pstart123 --silent; do sleep 2; done'
                     else
                         timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
                     fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,31 @@ jobs:
             DB_PASSWORD: start123
             DB_DATABASE: app
 
+        services:
+            mysql:
+                image: mysql:9
+                env:
+                    MYSQL_ROOT_PASSWORD: start123
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="mysqladmin ping -h localhost -pstart123"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
+            postgres:
+                image: postgres:18
+                env:
+                    POSTGRES_PASSWORD: start123
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U postgres"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
         steps:
             -   name: Checkout
                 uses: actions/checkout@v6
@@ -187,17 +212,6 @@ jobs:
                     fi
                     echo "Found $count migration(s)"
                     echo "MIGRATION_COUNT=$count" >> "$GITHUB_ENV"
-
-            -   name: Start ${{ matrix.db }}
-                run: docker compose up -d ${{ matrix.db }}
-
-            -   name: Wait for ${{ matrix.db }} to be ready
-                run: |
-                    if [ "${{ matrix.db }}" = "mysql" ]; then
-                        timeout 120 bash -c 'until docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" mysql mysqladmin ping -h127.0.0.1 -uroot --silent; do sleep 2; done'
-                    else
-                        timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
-                    fi
 
             -   name: Run migrations forward
                 working-directory: apps/${{ matrix.service }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,7 +178,9 @@ jobs:
             -   name: Verify compiled migrations exist
                 working-directory: apps/${{ matrix.service }}
                 run: |
-                    count=$(ls dist/adapters/database/migrations/${{ matrix.db }}/*.mjs 2>/dev/null | wc -l | tr -d ' ')
+                    shopt -s nullglob
+                    files=(dist/adapters/database/migrations/${{ matrix.db }}/*.mjs)
+                    count=${#files[@]}
                     if [ "$count" = "0" ]; then
                         echo "ERROR: no compiled migrations in apps/${{ matrix.service }}/dist/adapters/database/migrations/${{ matrix.db }}/"
                         exit 1
@@ -192,7 +194,7 @@ jobs:
             -   name: Wait for ${{ matrix.db }} to be ready
                 run: |
                     if [ "${{ matrix.db }}" = "mysql" ]; then
-                        timeout 120 bash -c 'until docker compose exec -T mysql mysqladmin ping -h127.0.0.1 -uroot -pstart123 --silent; do sleep 2; done'
+                        timeout 120 bash -c 'until docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" mysql mysqladmin ping -h127.0.0.1 -uroot --silent; do sleep 2; done'
                     else
                         timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
                     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.9'
 services:
     mysql:
-        image: mysql
+        image: mysql:9
         restart: always
         healthcheck:
             test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
@@ -14,7 +14,7 @@ services:
         ports:
             - '3306:3306'
     postgres:
-        image: postgres
+        image: postgres:18
         restart: always
         healthcheck:
             test: [ "CMD", "pg_isready" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2414,16 +2414,6 @@
             "integrity": "sha512-00+4zWS0df0RBHNuQUixzBhYLzyqSDvBr7VsQiReT0fv2r52/mqNHcPNp4cts6O/bDIvz5O6Zw0S4jlNug9Kkw==",
             "license": "MIT"
         },
-        "node_modules/@ebec/http": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ebec/http/-/http-2.3.0.tgz",
-            "integrity": "sha512-7rPG7Bau1/reO/nQc+bpQABFvVj4+hFpARAgJcujrxGMuyq/ydN0+hjAJzxQDmwkfGY9GANfeCPUEwGuwmdjiQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ebec": "^2.3.0"
-            }
-        },
         "node_modules/@emnapi/core": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -26353,60 +26343,14 @@
             "version": "0.8.21",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@privateaim/kit": "^0.8.21",
-                "@privateaim/server-kit": "^0.8.21",
+                "@privateaim/kit": "^0.9.0",
+                "@privateaim/server-kit": "^0.9.0",
                 "@privateaim/storage-kit": "^0.8.21"
             },
             "peerDependencies": {
-                "@privateaim/kit": "^0.8.21",
-                "@privateaim/server-kit": "^0.8.21",
+                "@privateaim/kit": "^0.9.0",
+                "@privateaim/server-kit": "^0.9.0",
                 "@privateaim/storage-kit": "^0.8.21"
-            }
-        },
-        "packages/server-storage-kit/node_modules/@privateaim/kit": {
-            "version": "0.8.43",
-            "resolved": "https://registry.npmjs.org/@privateaim/kit/-/kit-0.8.43.tgz",
-            "integrity": "sha512-uBSIKqHzvv2I0GHVDABi13htTOvUnU/GNNS288t+7Cvn89lFuGAEqJZaCiMpkA/Wi96necJB5F29EJosdXC9rw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ebec/http": "^2.3.0",
-                "nanoid": "^5.1.11",
-                "validup": "^0.2.2"
-            },
-            "peerDependencies": {
-                "@authup/core-kit": "^1.0.0-beta.36",
-                "@authup/kit": "^1.0.0-beta.36"
-            }
-        },
-        "packages/server-storage-kit/node_modules/@privateaim/server-kit": {
-            "version": "0.8.43",
-            "resolved": "https://registry.npmjs.org/@privateaim/server-kit/-/server-kit-0.8.43.tgz",
-            "integrity": "sha512-QXlZcoet/uCy2s199+2JI8VRtx1MX4RJjYuGKxu79K3aW9MUSbupY8EFy33l4dUtnTZ2Ew30Y194RHBq06r/4g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ebec/http": "^2.3.0",
-                "@hapic/oauth2": "^3.2.0",
-                "@isaacs/ttlcache": "^2.1.4",
-                "@privateaim/kit": "^0.8.43",
-                "@socket.io/redis-emitter": "^5.1.0",
-                "eldin": "^1.1.0",
-                "envix": "^1.5.0",
-                "hapic": "^2.8.2",
-                "orkos": "^1.1.1",
-                "triple-beam": "^1.4.1",
-                "winston": "^3.19.0",
-                "winston-transport": "^4.9.0"
-            },
-            "peerDependencies": {
-                "@authup/access": "^1.0.0-beta.36",
-                "@authup/core-http-kit": "^1.0.0-beta.36",
-                "@authup/core-kit": "^1.0.0-beta.36",
-                "amqp-extension": "^4.0.0",
-                "rapiq": "^0.9.0",
-                "redis-extension": "^2.0.4",
-                "typeorm-extension": "^3.7.4"
             }
         },
         "packages/server-telemetry": {
@@ -26479,59 +26423,13 @@
                 "@authup/access": "^1.0.0-beta.36",
                 "@authup/core-kit": "^1.0.0-beta.36",
                 "@privateaim/errors": "^0.8.42",
-                "@privateaim/server-kit": "^0.8.37"
+                "@privateaim/server-kit": "^0.9.0"
             },
             "peerDependencies": {
                 "@authup/access": "^1.0.0-beta.36",
                 "@authup/core-kit": "^1.0.0-beta.36",
                 "@privateaim/errors": "^0.8.42",
-                "@privateaim/server-kit": "^0.8.37"
-            }
-        },
-        "packages/server-test-kit/node_modules/@privateaim/kit": {
-            "version": "0.8.43",
-            "resolved": "https://registry.npmjs.org/@privateaim/kit/-/kit-0.8.43.tgz",
-            "integrity": "sha512-uBSIKqHzvv2I0GHVDABi13htTOvUnU/GNNS288t+7Cvn89lFuGAEqJZaCiMpkA/Wi96necJB5F29EJosdXC9rw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ebec/http": "^2.3.0",
-                "nanoid": "^5.1.11",
-                "validup": "^0.2.2"
-            },
-            "peerDependencies": {
-                "@authup/core-kit": "^1.0.0-beta.36",
-                "@authup/kit": "^1.0.0-beta.36"
-            }
-        },
-        "packages/server-test-kit/node_modules/@privateaim/server-kit": {
-            "version": "0.8.43",
-            "resolved": "https://registry.npmjs.org/@privateaim/server-kit/-/server-kit-0.8.43.tgz",
-            "integrity": "sha512-QXlZcoet/uCy2s199+2JI8VRtx1MX4RJjYuGKxu79K3aW9MUSbupY8EFy33l4dUtnTZ2Ew30Y194RHBq06r/4g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ebec/http": "^2.3.0",
-                "@hapic/oauth2": "^3.2.0",
-                "@isaacs/ttlcache": "^2.1.4",
-                "@privateaim/kit": "^0.8.43",
-                "@socket.io/redis-emitter": "^5.1.0",
-                "eldin": "^1.1.0",
-                "envix": "^1.5.0",
-                "hapic": "^2.8.2",
-                "orkos": "^1.1.1",
-                "triple-beam": "^1.4.1",
-                "winston": "^3.19.0",
-                "winston-transport": "^4.9.0"
-            },
-            "peerDependencies": {
-                "@authup/access": "^1.0.0-beta.36",
-                "@authup/core-http-kit": "^1.0.0-beta.36",
-                "@authup/core-kit": "^1.0.0-beta.36",
-                "amqp-extension": "^4.0.0",
-                "rapiq": "^0.9.0",
-                "redis-extension": "^2.0.4",
-                "typeorm-extension": "^3.7.4"
+                "@privateaim/server-kit": "^0.9.0"
             }
         },
         "packages/storage-kit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2414,6 +2414,16 @@
             "integrity": "sha512-00+4zWS0df0RBHNuQUixzBhYLzyqSDvBr7VsQiReT0fv2r52/mqNHcPNp4cts6O/bDIvz5O6Zw0S4jlNug9Kkw==",
             "license": "MIT"
         },
+        "node_modules/@ebec/http": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ebec/http/-/http-2.3.0.tgz",
+            "integrity": "sha512-7rPG7Bau1/reO/nQc+bpQABFvVj4+hFpARAgJcujrxGMuyq/ydN0+hjAJzxQDmwkfGY9GANfeCPUEwGuwmdjiQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ebec": "^2.3.0"
+            }
+        },
         "node_modules/@emnapi/core": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -26353,6 +26363,52 @@
                 "@privateaim/storage-kit": "^0.8.21"
             }
         },
+        "packages/server-storage-kit/node_modules/@privateaim/kit": {
+            "version": "0.8.43",
+            "resolved": "https://registry.npmjs.org/@privateaim/kit/-/kit-0.8.43.tgz",
+            "integrity": "sha512-uBSIKqHzvv2I0GHVDABi13htTOvUnU/GNNS288t+7Cvn89lFuGAEqJZaCiMpkA/Wi96necJB5F29EJosdXC9rw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ebec/http": "^2.3.0",
+                "nanoid": "^5.1.11",
+                "validup": "^0.2.2"
+            },
+            "peerDependencies": {
+                "@authup/core-kit": "^1.0.0-beta.36",
+                "@authup/kit": "^1.0.0-beta.36"
+            }
+        },
+        "packages/server-storage-kit/node_modules/@privateaim/server-kit": {
+            "version": "0.8.43",
+            "resolved": "https://registry.npmjs.org/@privateaim/server-kit/-/server-kit-0.8.43.tgz",
+            "integrity": "sha512-QXlZcoet/uCy2s199+2JI8VRtx1MX4RJjYuGKxu79K3aW9MUSbupY8EFy33l4dUtnTZ2Ew30Y194RHBq06r/4g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ebec/http": "^2.3.0",
+                "@hapic/oauth2": "^3.2.0",
+                "@isaacs/ttlcache": "^2.1.4",
+                "@privateaim/kit": "^0.8.43",
+                "@socket.io/redis-emitter": "^5.1.0",
+                "eldin": "^1.1.0",
+                "envix": "^1.5.0",
+                "hapic": "^2.8.2",
+                "orkos": "^1.1.1",
+                "triple-beam": "^1.4.1",
+                "winston": "^3.19.0",
+                "winston-transport": "^4.9.0"
+            },
+            "peerDependencies": {
+                "@authup/access": "^1.0.0-beta.36",
+                "@authup/core-http-kit": "^1.0.0-beta.36",
+                "@authup/core-kit": "^1.0.0-beta.36",
+                "amqp-extension": "^4.0.0",
+                "rapiq": "^0.9.0",
+                "redis-extension": "^2.0.4",
+                "typeorm-extension": "^3.7.4"
+            }
+        },
         "packages/server-telemetry": {
             "name": "@privateaim/server-telemetry",
             "version": "0.9.0",
@@ -26430,6 +26486,52 @@
                 "@authup/core-kit": "^1.0.0-beta.36",
                 "@privateaim/errors": "^0.8.42",
                 "@privateaim/server-kit": "^0.8.37"
+            }
+        },
+        "packages/server-test-kit/node_modules/@privateaim/kit": {
+            "version": "0.8.43",
+            "resolved": "https://registry.npmjs.org/@privateaim/kit/-/kit-0.8.43.tgz",
+            "integrity": "sha512-uBSIKqHzvv2I0GHVDABi13htTOvUnU/GNNS288t+7Cvn89lFuGAEqJZaCiMpkA/Wi96necJB5F29EJosdXC9rw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ebec/http": "^2.3.0",
+                "nanoid": "^5.1.11",
+                "validup": "^0.2.2"
+            },
+            "peerDependencies": {
+                "@authup/core-kit": "^1.0.0-beta.36",
+                "@authup/kit": "^1.0.0-beta.36"
+            }
+        },
+        "packages/server-test-kit/node_modules/@privateaim/server-kit": {
+            "version": "0.8.43",
+            "resolved": "https://registry.npmjs.org/@privateaim/server-kit/-/server-kit-0.8.43.tgz",
+            "integrity": "sha512-QXlZcoet/uCy2s199+2JI8VRtx1MX4RJjYuGKxu79K3aW9MUSbupY8EFy33l4dUtnTZ2Ew30Y194RHBq06r/4g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ebec/http": "^2.3.0",
+                "@hapic/oauth2": "^3.2.0",
+                "@isaacs/ttlcache": "^2.1.4",
+                "@privateaim/kit": "^0.8.43",
+                "@socket.io/redis-emitter": "^5.1.0",
+                "eldin": "^1.1.0",
+                "envix": "^1.5.0",
+                "hapic": "^2.8.2",
+                "orkos": "^1.1.1",
+                "triple-beam": "^1.4.1",
+                "winston": "^3.19.0",
+                "winston-transport": "^4.9.0"
+            },
+            "peerDependencies": {
+                "@authup/access": "^1.0.0-beta.36",
+                "@authup/core-http-kit": "^1.0.0-beta.36",
+                "@authup/core-kit": "^1.0.0-beta.36",
+                "amqp-extension": "^4.0.0",
+                "rapiq": "^0.9.0",
+                "redis-extension": "^2.0.4",
+                "typeorm-extension": "^3.7.4"
             }
         },
         "packages/storage-kit": {

--- a/packages/server-storage-kit/package.json
+++ b/packages/server-storage-kit/package.json
@@ -19,13 +19,13 @@
     "license": "Apache-2.0",
     "description": "This package contains server side db helpers & utilities.",
     "devDependencies": {
-        "@privateaim/kit": "^0.8.21",
-        "@privateaim/server-kit": "^0.8.21",
+        "@privateaim/kit": "^0.9.0",
+        "@privateaim/server-kit": "^0.9.0",
         "@privateaim/storage-kit": "^0.8.21"
     },
     "peerDependencies": {
-        "@privateaim/kit": "^0.8.21",
-        "@privateaim/server-kit": "^0.8.21",
+        "@privateaim/kit": "^0.9.0",
+        "@privateaim/server-kit": "^0.9.0",
         "@privateaim/storage-kit": "^0.8.21"
     },
     "scripts": {

--- a/packages/server-test-kit/package.json
+++ b/packages/server-test-kit/package.json
@@ -22,13 +22,13 @@
         "@authup/access": "^1.0.0-beta.36",
         "@authup/core-kit": "^1.0.0-beta.36",
         "@privateaim/errors": "^0.8.42",
-        "@privateaim/server-kit": "^0.8.37"
+        "@privateaim/server-kit": "^0.9.0"
     },
     "peerDependencies": {
         "@authup/access": "^1.0.0-beta.36",
         "@authup/core-kit": "^1.0.0-beta.36",
         "@privateaim/errors": "^0.8.42",
-        "@privateaim/server-kit": "^0.8.37"
+        "@privateaim/server-kit": "^0.9.0"
     },
     "scripts": {
         "build": "rimraf ./dist && tsdown"


### PR DESCRIPTION
## Summary

- New `tests-migrations` CI job runs the migration CLI end-to-end against fresh MySQL and PostgreSQL containers for `server-core`, `server-storage`, and `server-telemetry`: `migration run` → revert all in reverse order → `migration run` (idempotency replay). Every `up()` / `down()` gets exercised, not just the latest migration.
- Pre-flight step counts compiled migrations in `apps/<service>/dist/adapters/database/migrations/<db>/` and fails loudly if zero. Without this guard, typeorm silently reports "No migrations are pending" with exit 0 when the CLI runs from the wrong working directory — the same silent-pass failure mode this job exists to fix.
- Pin `docker-compose.yml` images to `mysql:9` and `postgres:18` to match the versions used by the existing `test` job, eliminating drift between the migration job and local development.

## Why

The existing `test` job in `.github/workflows/main.yml` runs against MySQL and PostgreSQL — but the test database module overrides the schema bootstrap with `dataSource.synchronize()` (see `apps/<service>/test/app/database.ts`), which builds tables from entity metadata. Migration SQL files in `apps/<service>/src/adapters/database/migrations/{mysql,postgres}/` are silently ignored, so broken DDL only surfaces in production deployments.

Mirrors the fix landed in authup/authup#3068 (issue authup/authup#3067).

## What it catches

- SQL syntax errors in either DB
- Cross-DB type / quoting mismatches
- `down()` regressions in **any** migration (not just the latest)
- Idempotency: re-applying the full chain after a full revert

## What it still doesn't catch

- Data-correctness bugs in `UPDATE` / `INSERT` migrations against pre-existing rows (the migrations run against an empty DB). Listed as the stretch goal in authup/authup#3067 — not addressed here.

## Test plan

- [ ] CI: all 6 `tests-migrations` matrix combinations (3 services × 2 DBs) green
- [ ] Verify the pre-flight sanity check fails clearly if `dist/adapters/database/migrations/<db>/` is empty
- [ ] Spot-check job logs for the expected `1 migrations were found in the source code` line on first `migration run`, the matching reverted lines during the revert loop, and `1 migrations are new migrations must be executed` on the idempotency replay

Local verification (already done): full `run → revert × N → run` cycle against the docker-compose MySQL and PostgreSQL containers for all three services — every migration applied, reverted, and re-applied cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow that validates database migrations across services and database platforms by running, reverting, and re-running migrations to ensure forward/reverse correctness and idempotency.
  * Pinned database container image versions (MySQL 9, Postgres 18) for reproducible test environments.
  * Bumped internal package dependency versions for server tooling.

* **Documentation**
  * Added migration testing docs with local run instructions and a pre-flight check for compiled migration artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/hub/pull/1629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->