### PR TITLE
fix: widen build_size / bucket file size to bigint

### DIFF
--- a/apps/server-core/src/adapters/database/entities/analysis.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis.ts
@@ -140,6 +140,7 @@ export class AnalysisEntity implements Analysis {
 
     @Column({
         type: 'bigint',
+        unsigned: true,
         nullable: true,
         default: null,
         transformer: bigintNumberTransformer,

--- a/apps/server-core/src/adapters/database/entities/analysis.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis.ts
@@ -13,6 +13,7 @@ import type {
     Project,
     Registry,
 } from '@privateaim/core-kit';
+import { bigintNumberTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -138,10 +139,10 @@ export class AnalysisEntity implements Analysis {
     build_os: string | null;
 
     @Column({
-        type: 'int',
-        unsigned: true,
+        type: 'bigint',
         nullable: true,
         default: null,
+        transformer: bigintNumberTransformer,
     })
     build_size: number | null;
 

--- a/apps/server-core/src/adapters/database/entities/master-image.ts
+++ b/apps/server-core/src/adapters/database/entities/master-image.ts
@@ -51,6 +51,7 @@ export class MasterImageEntity implements MasterImage {
 
     @Column({
         type: 'bigint',
+        unsigned: true,
         nullable: true,
         default: null,
         transformer: bigintNumberTransformer,

--- a/apps/server-core/src/adapters/database/entities/master-image.ts
+++ b/apps/server-core/src/adapters/database/entities/master-image.ts
@@ -7,6 +7,7 @@
 
 import { deserialize, serialize } from '@authup/kit';
 import type { ProcessStatus } from '@privateaim/kit';
+import { bigintNumberTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -49,10 +50,10 @@ export class MasterImageEntity implements MasterImage {
     build_hash: string | null;
 
     @Column({
-        type: 'int',
-        unsigned: true,
+        type: 'bigint',
         nullable: true,
         default: null,
+        transformer: bigintNumberTransformer,
     })
     build_size: number | null;
 

--- a/apps/server-core/src/adapters/database/migrations/mysql/1779354335393-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1779354335393-Default.ts
@@ -1,0 +1,46 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Default1779354335393 implements MigrationInterface {
+    name = 'Default1779354335393';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`master_images\` MODIFY COLUMN \`build_size\` bigint NULL
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`analysis_entity\` MODIFY COLUMN \`build_size\` bigint NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const [analysisRow] = await queryRunner.query(`
+            SELECT COUNT(*) AS overflow_count
+            FROM \`analysis_entity\`
+            WHERE \`build_size\` IS NOT NULL
+              AND (\`build_size\` > 4294967295 OR \`build_size\` < 0)
+        `);
+        const [masterRow] = await queryRunner.query(`
+            SELECT COUNT(*) AS overflow_count
+            FROM \`master_images\`
+            WHERE \`build_size\` IS NOT NULL
+              AND (\`build_size\` > 4294967295 OR \`build_size\` < 0)
+        `);
+
+        const analysisOverflow = Number(analysisRow.overflow_count);
+        const masterOverflow = Number(masterRow.overflow_count);
+
+        if (analysisOverflow > 0 || masterOverflow > 0) {
+            throw new Error(
+                'Rollback aborted: build_size values exceed the unsigned int range ' +
+                `(analysis_entity: ${analysisOverflow}, master_images: ${masterOverflow}).`,
+            );
+        }
+
+        await queryRunner.query(`
+            ALTER TABLE \`analysis_entity\` MODIFY COLUMN \`build_size\` int UNSIGNED NULL
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`master_images\` MODIFY COLUMN \`build_size\` int UNSIGNED NULL
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/mysql/1779354335393-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1779354335393-Default.ts
@@ -5,10 +5,10 @@ export class Default1779354335393 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            ALTER TABLE \`master_images\` MODIFY COLUMN \`build_size\` bigint NULL
+            ALTER TABLE \`master_images\` MODIFY COLUMN \`build_size\` bigint UNSIGNED NULL
         `);
         await queryRunner.query(`
-            ALTER TABLE \`analysis_entity\` MODIFY COLUMN \`build_size\` bigint NULL
+            ALTER TABLE \`analysis_entity\` MODIFY COLUMN \`build_size\` bigint UNSIGNED NULL
         `);
     }
 

--- a/apps/server-core/src/adapters/database/migrations/postgres/1779354335393-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1779354335393-Default.ts
@@ -14,13 +14,13 @@ export class Default1779354335393 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         const [{ overflow_count: analysisOverflow }] = await queryRunner.query(`
-            SELECT COUNT(*)::int AS overflow_count
+            SELECT COUNT(*) AS overflow_count
             FROM "analysis_entity"
             WHERE "build_size" IS NOT NULL
               AND ("build_size" > 2147483647 OR "build_size" < -2147483648)
         `);
         const [{ overflow_count: masterOverflow }] = await queryRunner.query(`
-            SELECT COUNT(*)::int AS overflow_count
+            SELECT COUNT(*) AS overflow_count
             FROM "master_images"
             WHERE "build_size" IS NOT NULL
               AND ("build_size" > 2147483647 OR "build_size" < -2147483648)

--- a/apps/server-core/src/adapters/database/migrations/postgres/1779354335393-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1779354335393-Default.ts
@@ -1,0 +1,43 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Default1779354335393 implements MigrationInterface {
+    name = 'Default1779354335393';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "master_images" ALTER COLUMN "build_size" TYPE bigint
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "analysis_entity" ALTER COLUMN "build_size" TYPE bigint
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const [{ overflow_count: analysisOverflow }] = await queryRunner.query(`
+            SELECT COUNT(*)::int AS overflow_count
+            FROM "analysis_entity"
+            WHERE "build_size" IS NOT NULL
+              AND ("build_size" > 2147483647 OR "build_size" < -2147483648)
+        `);
+        const [{ overflow_count: masterOverflow }] = await queryRunner.query(`
+            SELECT COUNT(*)::int AS overflow_count
+            FROM "master_images"
+            WHERE "build_size" IS NOT NULL
+              AND ("build_size" > 2147483647 OR "build_size" < -2147483648)
+        `);
+
+        if (Number(analysisOverflow) > 0 || Number(masterOverflow) > 0) {
+            throw new Error(
+                'Rollback aborted: build_size values exceed the integer range ' +
+                `(analysis_entity: ${analysisOverflow}, master_images: ${masterOverflow}).`,
+            );
+        }
+
+        await queryRunner.query(`
+            ALTER TABLE "analysis_entity" ALTER COLUMN "build_size" TYPE integer
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "master_images" ALTER COLUMN "build_size" TYPE integer
+        `);
+    }
+}

--- a/apps/server-core/src/app/aggregators/worker/analysis-builder/handler.ts
+++ b/apps/server-core/src/app/aggregators/worker/analysis-builder/handler.ts
@@ -59,7 +59,7 @@ export async function handleAnalysisBuilderEvent(
 
             entity.build_hash = temp.hash ?? null;
             entity.build_os = temp.os ?? null;
-            entity.build_size = temp.size != null ? Math.min(temp.size, 2147483647) : null;
+            entity.build_size = temp.size ?? null;
             entity.build_status = ProcessStatus.EXECUTED;
             entity.build_progress = 100;
             break;
@@ -74,7 +74,7 @@ export async function handleAnalysisBuilderEvent(
 
             entity.build_hash = temp.hash ?? null;
             entity.build_os = temp.os ?? null;
-            entity.build_size = temp.size != null ? Math.min(temp.size, 2147483647) : null;
+            entity.build_size = temp.size ?? null;
             entity.build_status = temp.status || null;
         }
     }

--- a/apps/server-core/src/cli/commands/migration.ts
+++ b/apps/server-core/src/cli/commands/migration.ts
@@ -113,7 +113,7 @@ export function defineCLIMigrationCommand() {
                 },
             ];
 
-            const baseDirectory = path.join(SRC_PATH, 'database', 'migrations');
+            const baseDirectory = path.join(SRC_PATH, 'adapters', 'database', 'migrations');
             const timestamp = Date.now();
 
             for (const connection of connections) {

--- a/apps/server-storage/src/adapters/database/entities/bucket-file.ts
+++ b/apps/server-storage/src/adapters/database/entities/bucket-file.ts
@@ -40,6 +40,7 @@ export class BucketFileEntity implements BucketFile {
 
     @Column({
         type: 'bigint',
+        unsigned: true,
         nullable: true,
         transformer: bigintNumberTransformer,
     })

--- a/apps/server-storage/src/adapters/database/entities/bucket-file.ts
+++ b/apps/server-storage/src/adapters/database/entities/bucket-file.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Realm } from '@authup/core-kit';
+import { bigintNumberTransformer } from '@privateaim/server-db-kit';
 import type { BucketFile } from '@privateaim/storage-kit';
 import {
     Column,
@@ -38,9 +39,9 @@ export class BucketFileEntity implements BucketFile {
     directory: string;
 
     @Column({
-        type: 'int',
-        unsigned: true,
+        type: 'bigint',
         nullable: true,
+        transformer: bigintNumberTransformer,
     })
     size: number | null;
 

--- a/apps/server-storage/src/adapters/database/migrations/mysql/1779354382106-Default.ts
+++ b/apps/server-storage/src/adapters/database/migrations/mysql/1779354382106-Default.ts
@@ -5,7 +5,7 @@ export class Default1779354382106 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            ALTER TABLE \`bucket_files\` MODIFY COLUMN \`size\` bigint NULL
+            ALTER TABLE \`bucket_files\` MODIFY COLUMN \`size\` bigint UNSIGNED NULL
         `);
     }
 

--- a/apps/server-storage/src/adapters/database/migrations/mysql/1779354382106-Default.ts
+++ b/apps/server-storage/src/adapters/database/migrations/mysql/1779354382106-Default.ts
@@ -1,0 +1,32 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Default1779354382106 implements MigrationInterface {
+    name = 'Default1779354382106';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`bucket_files\` MODIFY COLUMN \`size\` bigint NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const [row] = await queryRunner.query(`
+            SELECT COUNT(*) AS overflow_count
+            FROM \`bucket_files\`
+            WHERE \`size\` IS NOT NULL
+              AND (\`size\` > 4294967295 OR \`size\` < 0)
+        `);
+
+        const overflow = Number(row.overflow_count);
+
+        if (overflow > 0) {
+            throw new Error(
+                `Rollback aborted: bucket_files.size values exceed the unsigned int range (${overflow} rows).`,
+            );
+        }
+
+        await queryRunner.query(`
+            ALTER TABLE \`bucket_files\` MODIFY COLUMN \`size\` int UNSIGNED NULL
+        `);
+    }
+}

--- a/apps/server-storage/src/adapters/database/migrations/postgres/1779354382106-Default.ts
+++ b/apps/server-storage/src/adapters/database/migrations/postgres/1779354382106-Default.ts
@@ -1,0 +1,30 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Default1779354382106 implements MigrationInterface {
+    name = 'Default1779354382106';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "bucket_files" ALTER COLUMN "size" TYPE bigint
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const [{ overflow_count: overflow }] = await queryRunner.query(`
+            SELECT COUNT(*)::int AS overflow_count
+            FROM "bucket_files"
+            WHERE "size" IS NOT NULL
+              AND ("size" > 2147483647 OR "size" < -2147483648)
+        `);
+
+        if (Number(overflow) > 0) {
+            throw new Error(
+                `Rollback aborted: bucket_files.size values exceed the integer range (${overflow} rows).`,
+            );
+        }
+
+        await queryRunner.query(`
+            ALTER TABLE "bucket_files" ALTER COLUMN "size" TYPE integer
+        `);
+    }
+}

--- a/apps/server-storage/src/adapters/database/migrations/postgres/1779354382106-Default.ts
+++ b/apps/server-storage/src/adapters/database/migrations/postgres/1779354382106-Default.ts
@@ -11,7 +11,7 @@ export class Default1779354382106 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         const [{ overflow_count: overflow }] = await queryRunner.query(`
-            SELECT COUNT(*)::int AS overflow_count
+            SELECT COUNT(*) AS overflow_count
             FROM "bucket_files"
             WHERE "size" IS NOT NULL
               AND ("size" > 2147483647 OR "size" < -2147483648)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25898,7 +25898,10 @@
             },
             "devDependencies": {
                 "@authup/core-kit": "^1.0.0-beta.36",
-                "@authup/kit": "^1.0.0-beta.36"
+                "@authup/kit": "^1.0.0-beta.36",
+                "cross-env": "^10.1.0",
+                "unplugin-swc": "^1.5.5",
+                "vitest": "^4.1.7"
             },
             "peerDependencies": {
                 "@authup/core-kit": "^1.0.0-beta.36",

--- a/packages/client-vue/src/components/bucket-file/FBucketFile.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFile.vue
@@ -14,6 +14,7 @@ import {
     ref,
     watch,
 } from 'vue';
+import { humanFileSize } from '@privateaim/kit';
 import type { BucketFile } from '@privateaim/storage-kit';
 import { injectStorageHTTPClient } from '../../core';
 import { FBucketFileDownload } from './FBucketFileDownload';
@@ -118,6 +119,8 @@ export default defineComponent({
             isActive,
 
             isInFileList,
+
+            humanFileSize,
         };
     },
 });
@@ -148,7 +151,7 @@ export default defineComponent({
         </div>
         <template v-if="data">
             <div class="bucket-file-size">
-                {{ data.size }} Bytes
+                {{ humanFileSize(data.size) }}
             </div>
         </template>
         <template v-if="data">

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -20,7 +20,8 @@
     },
     "scripts": {
         "build": "rimraf ./dist && tsdown",
-        "build-watch": "rimraf ./dist && tsc -p tsconfig.build.json --watch"
+        "build-watch": "rimraf ./dist && tsc -p tsconfig.build.json --watch",
+        "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts"
     },
     "devDependencies": {
         "@authup/kit": "^1.0.0-beta.36",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -25,7 +25,10 @@
     },
     "devDependencies": {
         "@authup/kit": "^1.0.0-beta.36",
-        "@authup/core-kit": "^1.0.0-beta.36"
+        "@authup/core-kit": "^1.0.0-beta.36",
+        "cross-env": "^10.1.0",
+        "unplugin-swc": "^1.5.5",
+        "vitest": "^4.1.7"
     },
     "peerDependencies": {
         "@authup/kit": "^1.0.0-beta.36",

--- a/packages/kit/src/utils/file-size.ts
+++ b/packages/kit/src/utils/file-size.ts
@@ -5,11 +5,46 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export function humanFileSize(bytes: number, si : boolean = false, dp : number = 1) {
+export type HumanFileSizeInput = number | bigint | string | null | undefined;
+
+/**
+ * Format a byte count for human-readable display.
+ *
+ * Accepts `number`, `bigint`, or a numeric `string` (e.g. a stringified
+ * SQL `bigint` returned by some drivers/transports). `null` / `undefined` /
+ * non-numeric input renders as an empty string.
+ *
+ * For sizes above `Number.MAX_SAFE_INTEGER` (~9 PB) the conversion to `number`
+ * is lossy, but the resulting human-readable label is still accurate enough
+ * for display purposes.
+ */
+export function humanFileSize(bytes: HumanFileSizeInput, si: boolean = false, dp: number = 1): string {
+    if (bytes === null || typeof bytes === 'undefined') {
+        return '';
+    }
+
+    let value: number;
+    if (typeof bytes === 'number') {
+        value = bytes;
+    } else if (typeof bytes === 'bigint') {
+        value = Number(bytes);
+    } else {
+        // Reject empty / whitespace-only strings — Number('') === 0, which we
+        // don't want to render as "0 B" for what is effectively missing data.
+        if (bytes.trim() === '') {
+            return '';
+        }
+        value = Number(bytes);
+    }
+
+    if (!Number.isFinite(value)) {
+        return '';
+    }
+
     const thresh = si ? 1000 : 1024;
 
-    if (Math.abs(bytes) < thresh) {
-        return `${bytes} B`;
+    if (Math.abs(value) < thresh) {
+        return `${value} B`;
     }
 
     const units = si ?
@@ -19,9 +54,9 @@ export function humanFileSize(bytes: number, si : boolean = false, dp : number =
     const r = 10 ** dp;
 
     do {
-        bytes /= thresh;
+        value /= thresh;
         ++u;
-    } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
+    } while (Math.round(Math.abs(value) * r) / r >= thresh && u < units.length - 1);
 
-    return `${bytes.toFixed(dp)} ${units[u]}`;
+    return `${value.toFixed(dp)} ${units[u]}`;
 }

--- a/packages/kit/test/unit/utils/file-size.spec.ts
+++ b/packages/kit/test/unit/utils/file-size.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { humanFileSize } from '../../../src/utils/file-size';
+
+describe('humanFileSize', () => {
+    describe('null/undefined/invalid input', () => {
+        it('returns empty string for null', () => {
+            expect(humanFileSize(null)).toBe('');
+        });
+
+        it('returns empty string for undefined', () => {
+            expect(humanFileSize(undefined)).toBe('');
+        });
+
+        it('returns empty string for a non-numeric string', () => {
+            expect(humanFileSize('not-a-number')).toBe('');
+        });
+
+        it('returns empty string for an empty string', () => {
+            expect(humanFileSize('')).toBe('');
+        });
+
+        it('returns empty string for whitespace-only string', () => {
+            expect(humanFileSize('   ')).toBe('');
+        });
+
+        it('returns empty string for NaN', () => {
+            expect(humanFileSize(Number.NaN)).toBe('');
+        });
+
+        it('returns empty string for Infinity', () => {
+            expect(humanFileSize(Number.POSITIVE_INFINITY)).toBe('');
+        });
+    });
+
+    describe('number input (binary units, default)', () => {
+        it('returns bytes when under threshold', () => {
+            expect(humanFileSize(0)).toBe('0 B');
+            expect(humanFileSize(512)).toBe('512 B');
+            expect(humanFileSize(1023)).toBe('1023 B');
+        });
+
+        it('returns KiB at 1024 bytes', () => {
+            expect(humanFileSize(1024)).toBe('1.0 KiB');
+        });
+
+        it('returns MiB at 1024^2 bytes', () => {
+            expect(humanFileSize(1024 * 1024)).toBe('1.0 MiB');
+        });
+
+        it('returns GiB at 1024^3 bytes', () => {
+            expect(humanFileSize(1024 ** 3)).toBe('1.0 GiB');
+        });
+
+        it('rounds to the requested decimal places', () => {
+            expect(humanFileSize(1536, false, 1)).toBe('1.5 KiB');
+            expect(humanFileSize(1536, false, 2)).toBe('1.50 KiB');
+            expect(humanFileSize(1536, false, 0)).toBe('2 KiB');
+        });
+
+        it('handles negative values', () => {
+            expect(humanFileSize(-2048)).toBe('-2.0 KiB');
+        });
+    });
+
+    describe('number input (SI units)', () => {
+        it('returns kB at 1000 bytes when si=true', () => {
+            expect(humanFileSize(1000, true)).toBe('1.0 kB');
+        });
+
+        it('returns GB at 1e9 bytes when si=true', () => {
+            expect(humanFileSize(1_000_000_000, true)).toBe('1.0 GB');
+        });
+    });
+
+    describe('string input (stringified bigint)', () => {
+        it('parses a small numeric string', () => {
+            expect(humanFileSize('2048')).toBe('2.0 KiB');
+        });
+
+        it('parses the issue #1507 overflow value (~13 GB)', () => {
+            // 13_039_739_469 bytes — what triggered the original int overflow
+            expect(humanFileSize('13039739469')).toBe('12.1 GiB');
+        });
+
+        it('parses values up to Number.MAX_SAFE_INTEGER', () => {
+            // 9_007_199_254_740_991 bytes ≈ 8 PiB — upper end of safe integer
+            const safeMax = String(Number.MAX_SAFE_INTEGER);
+            expect(humanFileSize(safeMax)).toBe('8.0 PiB');
+        });
+    });
+
+    describe('bigint input', () => {
+        it('formats a small bigint', () => {
+            expect(humanFileSize(2048n)).toBe('2.0 KiB');
+        });
+
+        it('formats a bigint at the issue #1507 value', () => {
+            expect(humanFileSize(13_039_739_469n)).toBe('12.1 GiB');
+        });
+
+        it('formats a bigint beyond MAX_SAFE_INTEGER (lossy but reasonable)', () => {
+            // Above MAX_SAFE_INTEGER, Number() loses precision but the label
+            // (in PiB/EiB) is still meaningful for human display.
+            const huge = BigInt(Number.MAX_SAFE_INTEGER) * 4n;
+            expect(humanFileSize(huge)).toBe('32.0 PiB');
+        });
+    });
+});

--- a/packages/kit/test/vitest.config.ts
+++ b/packages/kit/test/vitest.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: { include: ['test/unit/**/*.spec.ts'] },
+    plugins: [swc.vite()],
+});

--- a/packages/server-db-kit/src/transformer/bigint-number.ts
+++ b/packages/server-db-kit/src/transformer/bigint-number.ts
@@ -10,14 +10,22 @@ import type { ValueTransformer } from 'typeorm';
 /**
  * TypeORM returns `bigint` columns as JS strings by default (both `pg` and
  * `mysql2`) to avoid silent precision loss. This transformer normalizes the
- * column to a `number | null` on read and passes values through on write.
+ * column to a `number | null` on read and validates the same invariant on
+ * write.
  *
- * It throws if the stored value cannot be represented exactly as a JS number
- * (i.e. exceeds `Number.MAX_SAFE_INTEGER`, ≈ 9 PB), so the failure is loud
- * rather than silently truncated.
+ * Both directions throw if the value cannot be represented exactly as a JS
+ * number (i.e. exceeds `Number.MAX_SAFE_INTEGER`, ≈ 9 PB), so precision loss
+ * is loud rather than silently persisted. Guarding `to()` also catches the
+ * problem at the write site, where the stack trace points to the caller
+ * instead of a downstream reader.
  */
 export const bigintNumberTransformer: ValueTransformer = {
     to(value: number | null | undefined): number | null | undefined {
+        if (typeof value === 'number' && !Number.isSafeInteger(value)) {
+            throw new Error(
+                `bigint value "${value}" exceeds Number.MAX_SAFE_INTEGER and cannot be represented as a JS number`,
+            );
+        }
         return value;
     },
     from(value: string | number | null | undefined): number | null {

--- a/packages/server-db-kit/src/transformer/bigint-number.ts
+++ b/packages/server-db-kit/src/transformer/bigint-number.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ValueTransformer } from 'typeorm';
+
+/**
+ * TypeORM returns `bigint` columns as JS strings by default (both `pg` and
+ * `mysql2`) to avoid silent precision loss. This transformer normalizes the
+ * column to a `number | null` on read and passes values through on write.
+ *
+ * It throws if the stored value cannot be represented exactly as a JS number
+ * (i.e. exceeds `Number.MAX_SAFE_INTEGER`, ≈ 9 PB), so the failure is loud
+ * rather than silently truncated.
+ */
+export const bigintNumberTransformer: ValueTransformer = {
+    to(value: number | null | undefined): number | null | undefined {
+        return value;
+    },
+    from(value: string | number | null | undefined): number | null {
+        if (value === null || typeof value === 'undefined') {
+            return null;
+        }
+
+        const parsed = typeof value === 'number' ? value : Number(value);
+        if (!Number.isSafeInteger(parsed)) {
+            throw new Error(
+                `bigint value "${value}" exceeds Number.MAX_SAFE_INTEGER and cannot be represented as a JS number`,
+            );
+        }
+
+        return parsed;
+    },
+};

--- a/packages/server-db-kit/src/transformer/index.ts
+++ b/packages/server-db-kit/src/transformer/index.ts
@@ -1,10 +1,8 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './data-source/index.ts';
-export * from './subscriber/index.ts';
-export * from './transformer/index.ts';
+export * from './bigint-number.ts';


### PR DESCRIPTION
## Summary

Postgres `int4` / MySQL `int UNSIGNED` overflow for analyses and master images whose Docker build exceeds 2.1 GB (signed) / 4.3 GB (unsigned). Real-world example from #1507: a 13 GB image hits `value "13039739469" is out of range for type integer` on save.

Widens the three affected columns to `bigint`:
- `Analysis.build_size` (server-core)
- `MasterImage.build_size` (server-core)
- `BucketFile.size` (server-storage)

Supersedes #1508. Closes #1507.

## What's in the box

- **Shared transformer** in `server-db-kit` (`bigintNumberTransformer`) — Postgres `pg` and `mysql2` return `bigint` as JS string by default; the transformer normalizes to `number` with a `Number.isSafeInteger` guard so silent precision loss becomes a loud throw. Keeps the existing `number | null` contract on `core-kit` / `storage-kit` types, so no consumer churn.
- **Drop the `Math.min(size, 2147483647)` clamping workaround** in the analysis-builder aggregator (`apps/server-core/src/app/aggregators/worker/analysis-builder/handler.ts`).
- **Migrations** (Postgres + MySQL for each service) use **in-place** `ALTER COLUMN TYPE bigint` / `MODIFY COLUMN bigint NULL` — the TypeORM generator emitted destructive `DROP COLUMN + ADD COLUMN`, which would have wiped existing values; replaced manually with widening ALTERs.
- **`down()` preflight checks** — a row-count query against the target int range; aborts with a descriptive error if any row would overflow on revert. Matches the suggestion from the #1508 review thread.
- **Consumer-side hardening** of `humanFileSize` — accepts `number | bigint | string | null | undefined`, returns empty string for invalid/missing input. Bootstrapped `@privateaim/kit` test infra and added 21 specs covering each input shape (including the #1507 13 GB value).
- **`FBucketFile.vue`** now renders via `humanFileSize(data.size)` instead of `{{ data.size }} Bytes` — matches `FAnalysisBuildStep.vue` and gracefully handles null.
- **Stale CLI path fix** in `apps/server-core/src/cli/commands/migration.ts` — `database/migrations` → `adapters/database/migrations` (server-storage/telemetry already had the correct path).

## Test plan

- [x] `npm run test` — 21 new kit tests + 318 server-core + 65 server-storage + others pass
- [x] `npm run build` — clean, all type declarations emit
- [x] `npm run lint` clean on every touched file
- [x] End-to-end `migration run → revert → run` cycle on Postgres + MySQL for **both** services
- [x] `information_schema.columns` / `SHOW COLUMNS` confirm `bigint` after `up()`
- [ ] `tests-migrations` CI job — will run the same `run → revert × N → run` flow against the new migrations

## Notes

- Branch was rebased onto the post-hexagonal layout (`apps/server-core/src/adapters/database/...`); #1508 was on pre-hexagonal paths and would have needed a full rebase anyway — close it referencing this PR.
- `Number.MAX_SAFE_INTEGER` ≈ 9 PB, well above any realistic image/file size; the guard makes overflow loud rather than silent for the theoretical future case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File sizes now display in human-readable format (e.g., 1.5 GB) in the bucket file component
  * Extended file size support to handle larger values with improved input compatibility

* **Tests**
  * Added comprehensive test suite for file size formatting utilities

* **Chores**
  * Added test framework configuration for the kit package

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/hub/pull/1631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->