### PR TITLE
feat: log entity references as labels instead of inline UUIDs

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -94,6 +94,29 @@ export const analysisSchema = z.object({
 });
 ```
 
+## Logging
+
+Logs flow through Winston → `LoggerTransport` (`packages/server-telemetry-kit/src/services/logger/transport.ts`) → telemetry/VictoriaLogs, where every string/number/boolean key of the metadata object becomes a **queryable label**. UI views (e.g. the analysis log panel) filter by these labels — see `AnalysisLogController`, which queries `ref_type=analysis` + `ref_id=<id>`.
+
+**Rule: keep human-readable tokens in the message; move opaque UUIDs to labels.**
+
+- **Human-readable tokens stay inline** — filenames, paths, entity names, enum-like types (`CODE`/`RESULT`, `user`/`robot`), counts. They give the line meaning; stripping them collapses distinct lines into identical text (`Packing file` × N).
+- **Opaque UUIDs move to labels** — never interpolate an entity id into the message string. Attach it via `LogFlag.REF_TYPE` + `LogFlag.REF_ID` (`packages/telemetry-kit/src/domains/log/constants.ts`) for the primary referenced entity, plus named labels (`bucket_id`, `target_id`, …) for secondary ids. `LogFlag.REF_TYPE` takes a `DomainType` value.
+
+```typescript
+// Bad — opaque UUID baked into the message, unreadable and unqueryable
+this.logger?.info(`Created bucket for analysis ${analysis.id}`);
+
+// Good — readable message, ids as labels (canonical pattern in
+// apps/server-core-worker/.../analysis-builder/handlers/execute/module.ts)
+this.logger?.info('Created bucket for analysis', {
+    [LogFlag.REF_TYPE]: DomainType.ANALYSIS,
+    [LogFlag.REF_ID]: analysis.id,
+});
+```
+
+Adding `REF_TYPE`/`REF_ID` also makes a log visible on the matching entity view (logs without them never surface there). Thrown `Error` messages and non-UUID descriptors (names, paths, counts, URLs) are exempt.
+
 ## Release Process
 
 Automated via **release-please** (Google) for versioning + **monoship** (`tada5hi/monoship@v2`) for npm publishing. Creates release PRs that bump versions across all packages in lockstep (current: 0.8.31).

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -101,14 +101,17 @@ Logs flow through Winston → `LoggerTransport` (`packages/server-telemetry-kit/
 **Rule: keep human-readable tokens in the message; move opaque UUIDs to labels.**
 
 - **Human-readable tokens stay inline** — filenames, paths, entity names, enum-like types (`CODE`/`RESULT`, `user`/`robot`), counts. They give the line meaning; stripping them collapses distinct lines into identical text (`Packing file` × N).
-- **Opaque UUIDs move to labels** — never interpolate an entity id into the message string. Attach it via `LogFlag.REF_TYPE` + `LogFlag.REF_ID` (`packages/telemetry-kit/src/domains/log/constants.ts`) for the primary referenced entity, plus named labels (`bucket_id`, `target_id`, …) for secondary ids. `LogFlag.REF_TYPE` takes a `DomainType` value.
+- **Opaque UUIDs move to labels** — never interpolate an entity id into the message string. Attach it via `LogFlag.REF_TYPE` + `LogFlag.REF_ID` (`packages/telemetry-kit/src/domains/log/constants.ts`) for the primary referenced entity, plus named labels (`bucket_id`, `target_id`, …) for secondary ids. `LogFlag.REF_TYPE` takes the referenced entity's `DomainType` — import it from **that entity's own kit** (`@privateaim/core-kit` for analysis, `@privateaim/storage-kit` for bucket/bucket-file), **not** telemetry-kit's `DomainType` (which only covers `event`/`log`).
 
 ```typescript
+import { DomainType } from '@privateaim/core-kit';
+import { LogFlag } from '@privateaim/telemetry-kit';
+
 // Bad — opaque UUID baked into the message, unreadable and unqueryable
 this.logger?.info(`Created bucket for analysis ${analysis.id}`);
 
 // Good — readable message, ids as labels (canonical pattern in
-// apps/server-core-worker/.../analysis-builder/handlers/execute/module.ts)
+// apps/server-core-worker/src/app/components/analysis-builder/handlers/execute/module.ts)
 this.logger?.info('Created bucket for analysis', {
     [LogFlag.REF_TYPE]: DomainType.ANALYSIS,
     [LogFlag.REF_ID]: analysis.id,

--- a/apps/server-core/src/app/aggregators/storage/bucket/handlers/creation_finished.ts
+++ b/apps/server-core/src/app/aggregators/storage/bucket/handlers/creation_finished.ts
@@ -43,7 +43,7 @@ export class StorageBucketCreationFinishedHandler extends BaseAggregatorHandler<
             const analysis = await analysisRepository.findOneBy({ id: task.data.analysisId });
 
             if (!analysis) {
-                this.logger?.info(`Analysis does not exist; ${task.data.bucketType} bucket can not be created`, {
+                this.logger?.info(`Analysis does not exist; ${task.data.bucketType} bucket cannot be created`, {
                     [LogFlag.REF_TYPE]: DomainType.ANALYSIS,
                     [LogFlag.REF_ID]: task.data.analysisId,
                     bucket_type: task.data.bucketType,

--- a/apps/server-core/src/app/aggregators/storage/bucket/handlers/creation_finished.ts
+++ b/apps/server-core/src/app/aggregators/storage/bucket/handlers/creation_finished.ts
@@ -4,9 +4,11 @@
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
+import { DomainType } from '@privateaim/core-kit';
 import type { ComponentHandlerContext } from '@privateaim/server-kit';
 import type { BucketComponentEventMap, BucketEvent } from '@privateaim/server-storage-kit';
 import type { Bucket } from '@privateaim/storage-kit';
+import { LogFlag } from '@privateaim/telemetry-kit';
 import { AnalysisBucketEntity, AnalysisEntity } from '../../../../../adapters/database/index.ts';
 import { TaskType } from '../../../../../core/domains/index.ts';
 import { BaseAggregatorHandler } from '../../../base.ts';
@@ -29,7 +31,11 @@ export class StorageBucketCreationFinishedHandler extends BaseAggregatorHandler<
             });
 
             if (analysisBucket) {
-                this.logger?.info(`Analysis ${task.data.bucketType} bucket already exists for analysis ${task.data.analysisId}.`);
+                this.logger?.info(`${task.data.bucketType} bucket already exists for analysis`, {
+                    [LogFlag.REF_TYPE]: DomainType.ANALYSIS,
+                    [LogFlag.REF_ID]: task.data.analysisId,
+                    bucket_type: task.data.bucketType,
+                });
                 return;
             }
 
@@ -37,7 +43,11 @@ export class StorageBucketCreationFinishedHandler extends BaseAggregatorHandler<
             const analysis = await analysisRepository.findOneBy({ id: task.data.analysisId });
 
             if (!analysis) {
-                this.logger?.info(`Analysis ${task.data.analysisId} does not exist. Therefore ${task.data.bucketType} bucket can not be created.`);
+                this.logger?.info(`Analysis does not exist; ${task.data.bucketType} bucket can not be created`, {
+                    [LogFlag.REF_TYPE]: DomainType.ANALYSIS,
+                    [LogFlag.REF_ID]: task.data.analysisId,
+                    bucket_type: task.data.bucketType,
+                });
                 return;
             }
 

--- a/apps/server-messenger/src/adapters/socket/controllers/messaging/module.ts
+++ b/apps/server-messenger/src/adapters/socket/controllers/messaging/module.ts
@@ -53,10 +53,12 @@ export function mountMessagingController(socket: Socket, options?: { logger?: Lo
         for (let i = 0; i < data.to.length; i++) {
             const to = data.to[i];
 
-            options?.logger?.info(`Sending message from ${from.id} (${from.type}) to ${to.id} (${to.type})`, {
+            options?.logger?.info(`Sending message from ${from.type} to ${to.type}`, {
                 [LogFlag.CHANNEL]: LogChannel.WEBSOCKET,
                 actor_type: from.type,
                 actor_id: from.id,
+                target_type: to.type,
+                target_id: to.id,
             });
 
             socket.in(buildConnectionRoomForIdentity(to))

--- a/apps/server-storage/src/adapters/http/controllers/bucket-file/module.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket-file/module.ts
@@ -9,7 +9,9 @@ import { Readable } from 'node:stream';
 import { createGzip } from 'node:zlib';
 import { EntityNotFoundError } from '@privateaim/errors';
 import type { BucketFile } from '@privateaim/storage-kit';
+import { DomainType } from '@privateaim/storage-kit';
 import type { Logger } from '@privateaim/server-kit';
+import { LogFlag } from '@privateaim/telemetry-kit';
 import {
     DContext,
     DController,
@@ -79,11 +81,19 @@ export class BucketFileController {
 
         const bucketName = toBucketName(entity.bucket_id);
 
-        this.logger?.debug(`Streaming file ${entity.hash} (${id}) of ${bucketName}`);
+        this.logger?.debug(`Streaming file ${entity.path}`, {
+            [LogFlag.REF_TYPE]: DomainType.BUCKET_FILE,
+            [LogFlag.REF_ID]: id,
+            bucket_id: entity.bucket_id,
+        });
 
         const nodeStream = await this.storage.getObject(bucketName, entity.hash);
         nodeStream.on('end', () => {
-            this.logger?.debug(`Streamed file ${entity.hash} (${id}) of ${bucketName}`);
+            this.logger?.debug(`Streamed file ${entity.path}`, {
+                [LogFlag.REF_TYPE]: DomainType.BUCKET_FILE,
+                [LogFlag.REF_ID]: id,
+                bucket_id: entity.bucket_id,
+            });
         });
         nodeStream.on('error', (err) => {
             this.logger?.error(err);

--- a/apps/server-storage/src/adapters/http/controllers/bucket/module.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket/module.ts
@@ -6,7 +6,9 @@
  */
 
 import type { Bucket, BucketCreatePayload } from '@privateaim/storage-kit';
+import { DomainType } from '@privateaim/storage-kit';
 import type { Logger } from '@privateaim/server-kit';
+import { LogFlag } from '@privateaim/telemetry-kit';
 import type { BucketFileEventCaller } from '@privateaim/server-storage-kit';
 import {
     DBody,
@@ -87,7 +89,10 @@ export class BucketController {
 
         const bucketName = toBucketName(entity.id);
 
-        this.logger?.debug(`Streaming files of ${bucketName}`);
+        this.logger?.debug(`Streaming files of bucket ${entity.name}`, {
+            [LogFlag.REF_TYPE]: DomainType.BUCKET,
+            [LogFlag.REF_ID]: entity.id,
+        });
 
         const stream = packBucketFiles(bucketName, files, this.storage, this.logger);
 

--- a/apps/server-storage/src/adapters/http/controllers/bucket/stream.ts
+++ b/apps/server-storage/src/adapters/http/controllers/bucket/stream.ts
@@ -8,6 +8,8 @@
 import { PassThrough, Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { Logger } from '@privateaim/server-kit';
+import { DomainType } from '@privateaim/storage-kit';
+import { LogFlag } from '@privateaim/telemetry-kit';
 import type { Pack } from 'tar-stream';
 import tar from 'tar-stream';
 import type { IStorageAdapter } from '../../../../core/storage/types.ts';
@@ -24,7 +26,11 @@ async function packFile(
         throw new Error(`Cannot pack bucket file ${file.id}: size is not recorded.`);
     }
 
-    logger?.debug(`Packing file ${file.path} (${file.id})`);
+    logger?.debug(`Packing file ${file.path}`, {
+        [LogFlag.REF_TYPE]: DomainType.BUCKET_FILE,
+        [LogFlag.REF_ID]: file.id,
+        bucket_id: file.bucket_id,
+    });
 
     const source = await storage.getObject(name, file.hash);
     const entry = pack.entry({


### PR DESCRIPTION
## Summary

Closes #1490.

System logs referenced entities (analyses, buckets, files, identities) by raw UUID interpolated into the message string — long, unreadable, and not queryable. This applies a codebase-wide convention: **human-readable tokens stay in the message; opaque UUIDs move to structured labels** (`LogFlag.REF_TYPE`/`REF_ID` + named labels), matching the pattern the worker's analysis-builder already used.

Labels flow through `LoggerTransport` → telemetry/VictoriaLogs as queryable fields, and views like the analysis log panel filter by `ref_type`/`ref_id`.

## Changes

**server-core** — `aggregators/storage/bucket/handlers/creation_finished.ts` (the issue's literal example)
- `Analysis CODE bucket already exists for analysis 7c1e8f12-…` → `CODE bucket already exists for analysis` + `ref_type=analysis`, `ref_id`, `bucket_type`.
- These logs carried **no** ref labels before, so they never appeared on the analysis view — now they do, and read cleanly.

**server-storage**
- `bucket/stream.ts` (`packFile`): `Packing file run_e2e.py (uuid)` → `Packing file run_e2e.py` + `ref_id`/`bucket_id` labels.
- `bucket-file/module.ts`: streaming/streamed logs use the readable `entity.path`; `id`/`bucket_id` become labels.
- `bucket/module.ts`: `Streaming files of <uuid-bucket-name>` → `Streaming files of bucket <name>` + `ref_type=bucket`/`ref_id`.

**server-messenger** — `messaging/module.ts`
- `Sending message from <uuid> (user) to <uuid> (robot)` → `Sending message from user to robot` + `actor_id`/`actor_type`/`target_id`/`target_type` labels.

**Docs** — added a **Logging** section to `.agents/conventions.md` documenting the rule (with good/bad example) so new code follows it.

Left untouched: non-UUID descriptors (counts, names, paths, URLs) and thrown `Error` messages.

## Verification

- `nx build` (incl. `tsc` type-check + swagger) — passing for all 3 services
- ESLint on changed files — clean
- Tests — server-core 318 ✅, server-storage 65 ✅ (server-messenger has no test target)

## Notes

The issue author asked to see the analysis *name* in logs. With this approach the message stays generic and the analysis view is already scoped by `ref_id`; rendering a name in a global/cross-analysis log view would be a separate UI-side `ref_id → name` enrichment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added logging conventions documenting structured log message formatting for improved consistency and traceability.

* **Refactor**
  * Updated logging across storage, messenger, and aggregator services to use structured metadata fields. Entity references and identifiers now appear in log metadata rather than embedded in message text, enhancing log readability and entity view integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->