### PR TITLE
feat(client-ui): add analysis settings tab to edit name and display_name

### DIFF
--- a/apps/client-ui/pages/analyses/[id].vue
+++ b/apps/client-ui/pages/analyses/[id].vue
@@ -5,12 +5,14 @@
   - view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
+import { usePermissionCheck } from '@authup/client-web-kit';
 import {
     DomainType,
 } from '@privateaim/core-kit';
 import { FDisplayName, createEntityManager } from '@privateaim/client-vue';
+import { PermissionName } from '@privateaim/kit';
 import { isClientErrorWithStatusCode } from 'hapic';
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import { definePageMeta, useToast } from '#imports';
 import {
     createError, 
@@ -35,6 +37,8 @@ export default defineComponent({
 
         const toast = useToast();
 
+        const canEdit = usePermissionCheck({ name: PermissionName.ANALYSIS_UPDATE });
+
         const manager = createEntityManager({
             type: `${DomainType.ANALYSIS}`,
             props: { entityId: useRoute().params.id as string },
@@ -55,38 +59,50 @@ export default defineComponent({
             throw createError({});
         }
 
-        const tabs = [
-            {
-                name: 'Overview', 
-                icon: 'fas fa-bars', 
-                path: '', 
-            },
-            {
-                name: 'Nodes', 
-                icon: 'fa fa-city', 
-                path: '/nodes', 
-            },
-            {
-                name: 'Code', 
-                icon: 'fa fa-code', 
-                path: '/code-files', 
-            },
-            {
-                name: 'Image', 
-                icon: 'fa fa-compact-disc', 
-                path: '/image', 
-            },
-            {
-                name: 'Security', 
-                icon: 'fa fa-lock', 
-                path: '/security', 
-            },
-            {
-                name: 'Results', 
-                icon: 'fas fa-chart-bar', 
-                path: '/result-files', 
-            },
-        ];
+        const tabs = computed(() => {
+            const items = [
+                {
+                    name: 'Overview',
+                    icon: 'fas fa-bars',
+                    path: '',
+                },
+                {
+                    name: 'Nodes',
+                    icon: 'fa fa-city',
+                    path: '/nodes',
+                },
+                {
+                    name: 'Code',
+                    icon: 'fa fa-code',
+                    path: '/code-files',
+                },
+                {
+                    name: 'Image',
+                    icon: 'fa fa-compact-disc',
+                    path: '/image',
+                },
+                {
+                    name: 'Security',
+                    icon: 'fa fa-lock',
+                    path: '/security',
+                },
+                {
+                    name: 'Results',
+                    icon: 'fas fa-chart-bar',
+                    path: '/result-files',
+                },
+            ];
+
+            if (canEdit.value) {
+                items.push({
+                    name: 'Settings',
+                    icon: 'fa fa-cog',
+                    path: '/settings',
+                });
+            }
+
+            return items;
+        });
 
         return {
             tabs,

--- a/apps/client-ui/pages/analyses/[id]/settings.vue
+++ b/apps/client-ui/pages/analyses/[id]/settings.vue
@@ -1,0 +1,58 @@
+<!--
+  - Copyright (c) 2025.
+  - Author Peter Placzek (tada5hi)
+  - For the full copyright and license information,
+  - view the LICENSE file that was distributed with this source code.
+  -->
+<script lang="ts">
+import { FAnalysisBasicForm } from '@privateaim/client-vue';
+import type { Analysis } from '@privateaim/core-kit';
+import { PermissionName } from '@privateaim/kit';
+import type { PropType } from 'vue';
+import { defineNuxtComponent } from '#app';
+import { LayoutKey, LayoutNavigationID } from '../../../config/layout';
+
+export default defineNuxtComponent({
+    meta: {
+        [LayoutKey.REQUIRED_LOGGED_IN]: true,
+        [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.DEFAULT,
+        [LayoutKey.REQUIRED_PERMISSIONS]: [
+            PermissionName.ANALYSIS_UPDATE,
+        ],
+    },
+    components: { FAnalysisBasicForm },
+    props: {
+        entity: {
+            type: Object as PropType<Analysis>,
+            required: true,
+        },
+    },
+    emits: ['updated'],
+    setup(props, { emit }) {
+        const handleUpdated = (entity: Analysis) => {
+            emit('updated', entity);
+        };
+
+        return { handleUpdated };
+    },
+});
+</script>
+<template>
+    <div v-if="entity">
+        <div class="card-grey card mb-3">
+            <div class="card-header">
+                <div class="d-flex flex-row w-100">
+                    <div>
+                        <span class="title">Settings</span>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <FAnalysisBasicForm
+                    :entity="entity"
+                    @updated="handleUpdated"
+                />
+            </div>
+        </div>
+    </div>
+</template>

--- a/packages/client-vue/src/components/analysis/FAnalysisBasicForm.vue
+++ b/packages/client-vue/src/components/analysis/FAnalysisBasicForm.vue
@@ -25,11 +25,14 @@ import {
     onMounted,
     reactive,
     ref,
+    watch,
 } from 'vue';
 import { VCFormInput } from '@vuecs/form-controls';
+import { useUpdatedAt } from '../../composables';
 import {
-    createEntityManager, 
-    defineEntityManagerEvents, 
+    createEntityManager,
+    defineEntityManagerEvents,
+    initFormAttributesFromSource,
     wrapFnWithBusyState,
 } from '../../core';
 import { FProjects } from '../project';
@@ -79,9 +82,25 @@ export default defineComponent({
 
         const proposalQuery = computed<BuildInput<Project>>(() => ({ filters: { ...(props.realmId ? { realm_id: props.realmId } : {}) } }));
 
+        const manager = createEntityManager({
+            type: `${DomainType.ANALYSIS}`,
+            setup,
+            props,
+        });
+
+        const isEditing = computed(() => !!manager.data.value);
+
         if (props.projectId) {
             form.project_id = props.projectId as string;
         }
+
+        const initFromProperties = () => {
+            if (!manager.data.value) return;
+
+            initFormAttributesFromSource(form, manager.data.value);
+        };
+
+        initFromProperties();
 
         // Pre-fill an editable, generated name suggestion when creating a new
         // analysis. Runs client-side only to avoid SSR hydration mismatches.
@@ -91,10 +110,14 @@ export default defineComponent({
             }
         });
 
-        const manager = createEntityManager({
-            type: `${DomainType.ANALYSIS}`,
-            setup,
-            props,
+        const updatedAt = useUpdatedAt(props.entity);
+
+        watch(updatedAt, (val, oldVal) => {
+            if (val && val !== oldVal) {
+                manager.data.value = props.entity;
+
+                initFromProperties();
+            }
         });
 
         const add = wrapFnWithBusyState(busy, async () => {
@@ -123,6 +146,7 @@ export default defineComponent({
             toggle,
             proposalQuery,
             busy,
+            isEditing,
         };
     },
 });
@@ -201,12 +225,17 @@ export default defineComponent({
                         :disabled="v$.$invalid || busy"
                         @click.prevent="add"
                     >
-                        <i class="fa fa-plus" /> create
+                        <template v-if="isEditing">
+                            <i class="fa fa-save" /> update
+                        </template>
+                        <template v-else>
+                            <i class="fa fa-plus" /> create
+                        </template>
                     </button>
                 </div>
             </div>
             <div
-                v-if="!projectId"
+                v-if="!projectId && !isEditing"
                 class="col"
             >
                 <FProjects :query="proposalQuery">


### PR DESCRIPTION
## Summary

Adds a permission-gated **Settings** tab to the analysis detail page (alongside Overview, Nodes, Code, Image, Security, Results) that renders `FAnalysisBasicForm` in edit mode — letting users change an analysis' `display_name`, `name`, and `description` after creation.

This follows the existing **Project → Settings** pattern (`projects/[id]/settings.vue` + `FProjectForm`).

## Changes

- **`packages/client-vue/.../FAnalysisBasicForm.vue`** — the form was create-only; made it edit-capable (mirroring `FProjectForm`):
  - Initializes fields from the passed `entity` via `initFormAttributesFromSource`.
  - Re-syncs on entity updates through a `useUpdatedAt` watch (so a successful update never leaves stale fields).
  - Hides the project picker column when editing (an analysis' project can't be reassigned).
  - Submit button now reads **"update"** (save icon) when editing vs **"create"** otherwise.
- **`apps/client-ui/pages/analyses/[id].vue`** — converted the static `tabs` array to a `computed` and added a **Settings** tab (`fa fa-cog`, `/settings`), gated on the `ANALYSIS_UPDATE` permission via `usePermissionCheck` — same approach the project page uses for `PROJECT_UPDATE`.
- **`apps/client-ui/pages/analyses/[id]/settings.vue`** (new) — thin tab page that renders the form in edit mode inside a `card-grey` card (consistent with the Security/Results tabs) and re-emits `updated` so the parent entity manager refreshes the header. Declares `REQUIRED_PERMISSIONS: [ANALYSIS_UPDATE]`.

## Notes / open questions

- **Tab label & placement:** used "Settings" + `fa fa-cog`, placed last — matching the project page. Easy to change to "General"/"Edit" or another position.
- **`configuration_locked`:** the form is **not** made read-only when the analysis is locked, since `name`/`display_name` are cosmetic metadata. Can gate on `entity.configuration_locked` (like the Security tab) if updates should be blocked while locked.

## Testing

- `npx nx build client-vue` passes (includes `vue-tsc` type-checking).
- ESLint passes on all three files; Husky pre-commit hooks (lint-staged + commitlint) passed.