### PR TITLE
feat(client-vue): show node type during project node selection

### DIFF
--- a/packages/client-vue/src/components/project/FProjectForm.ts
+++ b/packages/client-vue/src/components/project/FProjectForm.ts
@@ -228,23 +228,28 @@ const FProjectForm = defineComponent({
                             meta: props.meta,
                         }),
                     ],
-                    [EntityListSlotName.ITEM_ACTIONS]: (props: ListItemSlotProps<Node>) => {
-                        if (manager.data.value) {
-                            return h(FProjectNodeAssignAction, {
+                    [EntityListSlotName.ITEM]: (props: ListItemSlotProps<Node>) => {
+                        const action = manager.data.value ?
+                            h(FProjectNodeAssignAction, {
                                 key: props.data.id,
                                 nodeId: props.data.id,
                                 projectId: manager.data.value.id,
                                 realmId: manager.data.value.id,
+                            }) :
+                            renderEntityAssignAction({
+                                item: nodeIds.value.includes(props.data.id) ? props.data.id : undefined,
+                                add: () => toggleNodeIds(props.data.id),
+                                drop: () => toggleNodeIds(props.data.id),
                             });
-                        }
 
-                        const itemIndex = nodeIds.value.indexOf(props.data.id);
-
-                        return renderEntityAssignAction({
-                            item: itemIndex === -1 ? undefined : nodeIds.value[itemIndex],
-                            add: () => toggleNodeIds(props.data.id),
-                            drop: () => toggleNodeIds(props.data.id),
-                        });
+                        return h('div', { class: 'd-flex flex-row w-100' }, [
+                            h('div', [
+                                props.data.name,
+                                ' ',
+                                h('span', { class: 'text-muted' }, `(${props.data.type})`),
+                            ]),
+                            h('div', { class: 'ms-auto' }, [action]),
+                        ]);
                     },
                     [EntityListSlotName.FOOTER]: (props: ListFooterSlotProps<Node>) => h(FPagination, {
                         load: props.load,


### PR DESCRIPTION
## Summary

Resolves #1159.

When selecting nodes during project creation/edit, the node list relied on the default list-item rendering, which only shows a node's `name`. Users had no way to distinguish a `default` node from an `aggregator` node, leading to trial-and-error until an aggregator was found.

This change displays the node **type** alongside the name in the project node-selection list, as a muted parenthetical:

```
my-node-name (aggregator)                          [+]
```

## Implementation

- `FProjectForm.ts`: override the list `ITEM` slot to render `name (type)` plus the assign/unassign action.
- Providing an `ITEM` slot replaces the entire row in `@vuecs/list-controls` (including the default `ITEM_ACTIONS`), so the assign action is rendered inline within the slot. The action logic is unchanged — it still handles both create-mode (`nodeIds` toggle) and edit-mode (`FProjectNodeAssignAction`).
- The styling/markup (`text-muted` parenthetical) matches the existing convention already used in `FAnalysisNodePicker.vue` and `FAnalysisNodesManager.vue`, keeping node displays consistent across the app.

## Verification

- `eslint` — clean
- `vue-tsc` type check on `client-vue` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized node action UI layout in the project form for improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->