### PR TITLE
fix(analysis): make build & distribution check a reliable reconciliation path

### DIFF
--- a/apps/server-core-worker/src/adapters/docker/error.ts
+++ b/apps/server-core-worker/src/adapters/docker/error.ts
@@ -6,13 +6,37 @@
  */
 
 /**
- * Determine if an error is a docker daemon "no such object" (404) response,
- * as opposed to a connection/daemon failure where the object state is unknown.
+ * Determine if an error is a docker daemon HTTP response with the given
+ * status code, as opposed to a connection/daemon failure (no status code)
+ * where the object state is unknown.
+ *
+ * @param error
+ * @param statusCode
+ */
+export function isDockerErrorWithStatusCode(error: unknown, statusCode: number): boolean {
+    return error instanceof Error &&
+        'statusCode' in error &&
+        error.statusCode === statusCode;
+}
+
+/**
+ * Determine if an error is a docker daemon "no such object" (404) response.
  *
  * @param error
  */
 export function isDockerNotFoundError(error: unknown): boolean {
-    return error instanceof Error &&
-        'statusCode' in error &&
-        error.statusCode === 404;
+    return isDockerErrorWithStatusCode(error, 404);
+}
+
+/**
+ * Determine if an error from the /distribution endpoint denotes a missing
+ * registry image. The docker API responds 401 for both "no image found" and
+ * failed authentication (404 is included defensively); other responses
+ * (5xx, connection failures) leave the image state unknown.
+ *
+ * @param error
+ */
+export function isDockerDistributionImageMissingError(error: unknown): boolean {
+    return isDockerErrorWithStatusCode(error, 401) ||
+        isDockerErrorWithStatusCode(error, 404);
 }

--- a/apps/server-core-worker/src/adapters/docker/error.ts
+++ b/apps/server-core-worker/src/adapters/docker/error.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Determine if an error is a docker daemon "no such object" (404) response,
+ * as opposed to a connection/daemon failure where the object state is unknown.
+ *
+ * @param error
+ */
+export function isDockerNotFoundError(error: unknown): boolean {
+    return error instanceof Error &&
+        'statusCode' in error &&
+        error.statusCode === 404;
+}

--- a/apps/server-core-worker/src/adapters/docker/index.ts
+++ b/apps/server-core-worker/src/adapters/docker/index.ts
@@ -7,6 +7,7 @@
 
 export * from './auth-config.ts';
 export * from './container-pack.ts';
+export * from './error.ts';
 export * from './image-cleanup.ts';
 export * from './image-push.ts';
 export * from './registry.ts';

--- a/apps/server-core-worker/src/app/components/analysis-builder/handlers/check/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-builder/handlers/check/module.ts
@@ -5,26 +5,36 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { REGISTRY_ARTIFACT_TAG_LATEST } from '@privateaim/core-kit';
 import { ProcessStatus } from '@privateaim/kit';
+import { LogFlag } from '@privateaim/telemetry-kit';
 import type {
     AnalysisBuilderCheckPayload,
-    AnalysisBuilderCommand,
     AnalysisBuilderEventMap,
-    AnalysisBuilderExecutePayload,
 } from '@privateaim/server-core-worker-kit';
-import { AnalysisBuilderEvent } from '@privateaim/server-core-worker-kit';
-import type { ComponentHandler, ComponentHandlerContext } from '@privateaim/server-kit';
+import { AnalysisBuilderCommand, AnalysisBuilderEvent } from '@privateaim/server-core-worker-kit';
+import type { ComponentHandler, ComponentHandlerContext, Logger } from '@privateaim/server-kit';
 import type { Client as CoreClient } from '@privateaim/core-http-kit';
 import type { Client as DockerClient } from 'docken';
+import type { ImageInspectInfo } from 'dockerode';
+import { isDockerNotFoundError } from '../../../../../adapters/docker/index.ts';
+import { isAnalysisProcessStale } from '../../../helpers.ts';
 
 export class AnalysisBuilderCheckHandler implements ComponentHandler<AnalysisBuilderEventMap, AnalysisBuilderCommand.CHECK> {
     protected coreClient: CoreClient;
 
     protected docker: DockerClient;
 
-    constructor(ctx: { coreClient: CoreClient; docker: DockerClient }) {
+    protected logger: Logger | undefined;
+
+    constructor(ctx: {
+        coreClient: CoreClient; 
+        docker: DockerClient; 
+        logger?: Logger 
+    }) {
         this.coreClient = ctx.coreClient;
         this.docker = ctx.docker;
+        this.logger = ctx.logger;
     }
 
     async handle(
@@ -35,6 +45,14 @@ export class AnalysisBuilderCheckHandler implements ComponentHandler<AnalysisBui
             // todo: check if image exists, otherwise local queue task
             await this.handleInternal(value, context);
         } catch (e) {
+            this.logger?.error({
+                message: e,
+                command: AnalysisBuilderCommand.CHECK,
+                analysis_id: value.id,
+                [LogFlag.REF_ID]: value.id,
+                event: AnalysisBuilderEvent.CHECK_FAILED,
+            });
+
             await context.handle(
                 AnalysisBuilderEvent.CHECK_FAILED,
                 {
@@ -46,7 +64,7 @@ export class AnalysisBuilderCheckHandler implements ComponentHandler<AnalysisBui
     }
 
     async handleInternal(
-        value: AnalysisBuilderExecutePayload,
+        value: AnalysisBuilderCheckPayload,
         context: ComponentHandlerContext<AnalysisBuilderEventMap, AnalysisBuilderCommand.CHECK>,
     ): Promise<void> {
         await context.handle(
@@ -56,11 +74,21 @@ export class AnalysisBuilderCheckHandler implements ComponentHandler<AnalysisBui
 
         const analysis = await this.coreClient.analysis.getOne(value.id);
 
-        const image = this.docker.getImage(`${value.id}:latest`);
+        const image = this.docker.getImage(`${value.id}:${REGISTRY_ARTIFACT_TAG_LATEST}`);
+
+        let imageInfo : ImageInspectInfo | undefined;
 
         try {
-            const imageInfo = await image.inspect();
+            imageInfo = await image.inspect();
+        } catch (e) {
+            // anything but "no such image" means the daemon is broken,
+            // so the image state is unknown and no verdict can be made.
+            if (!isDockerNotFoundError(e)) {
+                throw e;
+            }
+        }
 
+        if (imageInfo) {
             await context.handle(
                 AnalysisBuilderEvent.CHECK_FINISHED,
                 {
@@ -71,26 +99,43 @@ export class AnalysisBuilderCheckHandler implements ComponentHandler<AnalysisBui
                     size: imageInfo.Size,
                 },
             );
-        } catch {
-            let status: `${ProcessStatus}`;
 
-            if (
-                analysis.build_status === ProcessStatus.STARTED ||
-                analysis.build_status === ProcessStatus.STARTING
-            ) {
-                // todo: if started & starting trigger is to far back in time, status should also be failed.
-                status = analysis.build_status;
-            } else {
-                status = ProcessStatus.FAILED;
-            }
-
-            await context.handle(
-                AnalysisBuilderEvent.CHECK_FINISHED,
-                {
-                    ...value,
-                    status,
-                },
-            );
+            return;
         }
+
+        let status: `${ProcessStatus}`;
+
+        if (
+            analysis.build_status === ProcessStatus.STARTED ||
+            analysis.build_status === ProcessStatus.STARTING
+        ) {
+            // an in-progress build refreshes the entity via progress events;
+            // a long-untouched one is orphaned (e.g. worker died) and recoverable as FAILED.
+            status = isAnalysisProcessStale(analysis.updated_at) ?
+                ProcessStatus.FAILED :
+                analysis.build_status;
+        } else if (analysis.build_status === ProcessStatus.EXECUTED) {
+            // fail-safe: the local image must only exist while no distribution
+            // explains its absence (the distributor removes it during/after a run).
+            if (
+                !analysis.distribution_status ||
+                analysis.distribution_status === ProcessStatus.FAILED ||
+                analysis.distribution_status === ProcessStatus.STOPPED
+            ) {
+                status = ProcessStatus.FAILED;
+            } else {
+                status = analysis.build_status;
+            }
+        } else {
+            status = ProcessStatus.FAILED;
+        }
+
+        await context.handle(
+            AnalysisBuilderEvent.CHECK_FINISHED,
+            {
+                ...value,
+                status,
+            },
+        );
     }
 }

--- a/apps/server-core-worker/src/app/components/analysis-builder/handlers/execute/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-builder/handlers/execute/module.ts
@@ -19,6 +19,7 @@ import {
 import { LogFlag } from '@privateaim/telemetry-kit';
 import type { ComponentHandler, ComponentHandlerContext, Logger } from '@privateaim/server-kit';
 import type { Client as CoreClient } from '@privateaim/core-http-kit';
+import { getManyAll } from '@privateaim/core-http-kit';
 import type { APIClient as StorageClient } from '@privateaim/storage-kit';
 import type { Client as DockerClient, ModemStreamWaitOptions  } from 'docken';
 import { waitForStream } from 'docken';
@@ -279,8 +280,10 @@ export class AnalysisBuilderExecuteHandler implements ComponentHandler<AnalysisB
             throw BuilderError.entrypointNotFound();
         }
 
-        const { data: analysisBucketFiles } = await this.coreClient
-            .analysisBucketFile.getMany({ filters: { analysis_bucket_id: analysisBucket.id } });
+        const analysisBucketFiles = await getManyAll((page) => this.coreClient.analysisBucketFile.getMany({
+            filters: { analysis_bucket_id: analysisBucket.id },
+            page,
+        }));
 
         const webStream = await this.storageClient.bucket.stream(analysisBucket.bucket_id);
         const nodeStream = stream.Readable.fromWeb(webStream as any);

--- a/apps/server-core-worker/src/app/components/analysis-builder/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-builder/module.ts
@@ -31,6 +31,7 @@ export class AnalysisBuilderComponent extends BaseComponent<AnalysisBuilderEvent
         this.mount(AnalysisBuilderCommand.CHECK, new AnalysisBuilderCheckHandler({
             coreClient: ctx.coreClient,
             docker: ctx.docker,
+            logger: ctx.logger,
         }));
         this.mount(AnalysisBuilderCommand.EXECUTE, new AnalysisBuilderExecuteHandler({
             coreClient: ctx.coreClient,

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
@@ -25,6 +25,7 @@ import type { Client as DockerClient } from 'docken';
 import {
     buildDockerAuthConfigFromRegistry,
     buildDockerImageURL,
+    isDockerDistributionImageMissingError,
 } from '../../../../../adapters/docker/index.ts';
 import { isAnalysisProcessStale } from '../../../helpers.ts';
 
@@ -143,7 +144,13 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
             }
 
             status = ProcessStatus.EXECUTED;
-        } catch {
+        } catch (e) {
+            // anything but a missing-image response (daemon down, registry 5xx)
+            // means the image state is unknown and no verdict can be made.
+            if (!isDockerDistributionImageMissingError(e)) {
+                throw e;
+            }
+
             if (
                 analysis.distribution_status === ProcessStatus.STARTED ||
                 analysis.distribution_status === ProcessStatus.STARTING

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
@@ -10,9 +10,8 @@ import {
 } from '@privateaim/core-kit';
 import { ProcessStatus } from '@privateaim/kit';
 import { LogFlag } from '@privateaim/telemetry-kit';
-import { waitForModemStream } from 'docken';
 import type {
-    AnalysisBuilderCheckPayload,
+    AnalysisDistributorCheckPayload,
     AnalysisDistributorEventMap,
 } from '@privateaim/server-core-worker-kit';
 import {
@@ -21,11 +20,13 @@ import {
 } from '@privateaim/server-core-worker-kit';
 import type { ComponentHandler, ComponentHandlerContext, Logger } from '@privateaim/server-kit';
 import type { Client as CoreClient } from '@privateaim/core-http-kit';
+import { getManyAll } from '@privateaim/core-http-kit';
 import type { Client as DockerClient } from 'docken';
 import {
     buildDockerAuthConfigFromRegistry,
     buildDockerImageURL,
 } from '../../../../../adapters/docker/index.ts';
+import { isAnalysisProcessStale } from '../../../helpers.ts';
 
 export class AnalysisDistributorCheckHandler implements ComponentHandler<AnalysisDistributorEventMap, AnalysisDistributorCommand.CHECK> {
     protected coreClient: CoreClient;
@@ -45,13 +46,21 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
     }
 
     async handle(
-        value: AnalysisBuilderCheckPayload,
+        value: AnalysisDistributorCheckPayload,
         context: ComponentHandlerContext<AnalysisDistributorEventMap, AnalysisDistributorCommand.CHECK>,
     ): Promise<void> {
         try {
             // todo: check if image exists, otherwise local queue task
             await this.handleInternal(value, context);
         } catch (e) {
+            this.logger?.error({
+                message: e,
+                command: AnalysisDistributorCommand.CHECK,
+                analysis_id: value.id,
+                [LogFlag.REF_ID]: value.id,
+                event: AnalysisDistributorEvent.CHECK_FAILED,
+            });
+
             await context.handle(
                 AnalysisDistributorEvent.CHECK_FAILED,
                 {
@@ -63,7 +72,7 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
     }
 
     async handleInternal(
-        value: AnalysisBuilderCheckPayload,
+        value: AnalysisDistributorCheckPayload,
         context: ComponentHandlerContext<AnalysisDistributorEventMap, AnalysisDistributorCommand.CHECK>,
     ): Promise<void> {
         await context.handle(
@@ -75,10 +84,10 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
 
         // -----------------------------------------------------------------------------------
 
-        const { data: analysisNodes } = await this.coreClient.analysisNode.getMany({
+        const analysisNodes = await getManyAll((page) => this.coreClient.analysisNode.getMany({
             filter: { analysis_id: analysis.id },
-            page: { limit: 1 },
-        });
+            page,
+        }));
 
         if (analysisNodes.length === 0) {
             await context.handle(
@@ -89,10 +98,11 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
             return;
         }
 
-        const { data: nodes } = await this.coreClient.node.getMany({
+        const nodes = await getManyAll((page) => this.coreClient.node.getMany({
             filter: { id: analysisNodes.map((analysisNode) => analysisNode.node_id) },
             relations: { registry_project: true },
-        });
+            page,
+        }));
 
         if (nodes.length === 0) {
             await context.handle(
@@ -108,6 +118,8 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
         const registry = await this.coreClient.registry.getOne(analysis.registry_id, { fields: ['+account_secret'] });
 
         const authConfig = buildDockerAuthConfigFromRegistry(registry);
+
+        let status: `${ProcessStatus}`;
 
         try {
             for (const node of nodes) {
@@ -125,31 +137,25 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
                     tagOrDigest: REGISTRY_ARTIFACT_TAG_LATEST,
                 });
 
-                const stream = await this.docker.pull(nodeImageURL, { authconfig: authConfig });
-                await waitForModemStream(this.docker.modem, stream);
+                // registry manifest lookup — verifies existence without pulling the image
+                await this.docker.getImage(nodeImageURL)
+                    .distribution({ authconfig: authConfig });
             }
-        } catch {
-            let status: `${ProcessStatus}`;
 
+            status = ProcessStatus.EXECUTED;
+        } catch {
             if (
                 analysis.distribution_status === ProcessStatus.STARTED ||
                 analysis.distribution_status === ProcessStatus.STARTING
             ) {
-                // todo: if started & starting trigger is to far back in time, status should also be failed.
-                status = analysis.build_status;
+                // an in-progress distribution refreshes the entity via progress events;
+                // a long-untouched one is orphaned (e.g. worker died) and recoverable as FAILED.
+                status = isAnalysisProcessStale(analysis.updated_at) ?
+                    ProcessStatus.FAILED :
+                    analysis.distribution_status;
             } else {
                 status = ProcessStatus.FAILED;
             }
-
-            await context.handle(
-                AnalysisDistributorEvent.CHECK_FINISHED,
-                {
-                    ...value,
-                    status,
-                },
-            );
-
-            return;
         }
 
         // -----------------------------------------------------------------------------------
@@ -158,7 +164,7 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
             AnalysisDistributorEvent.CHECK_FINISHED,
             {
                 ...value,
-                status: ProcessStatus.EXECUTED,
+                status,
             },
         );
     }

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/execute/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/execute/module.ts
@@ -18,6 +18,7 @@ import type { Analysis, Node, Registry } from '@privateaim/core-kit';
 import { REGISTRY_ARTIFACT_TAG_LATEST } from '@privateaim/core-kit';
 import { LogFlag } from '@privateaim/telemetry-kit';
 import type { Client as CoreClient } from '@privateaim/core-http-kit';
+import { getManyAll } from '@privateaim/core-http-kit';
 import type { Client as DockerClient, ModemStreamWaitOptions  } from 'docken';
 import type { ImagePushOptions } from 'dockerode';
 import { waitForStream } from 'docken';
@@ -83,17 +84,21 @@ export class AnalysisDistributorExecuteHandler implements ComponentHandler<Analy
         const analysis = await this.coreClient.analysis.getOne(value.id);
         const registry = await this.coreClient.registry.getOne(analysis.registry_id, { fields: ['+account_secret'] });
 
-        const { data: analysisNodes } = await this.coreClient.analysisNode.getMany({ filter: { analysis_id: analysis.id } });
+        const analysisNodes = await getManyAll((page) => this.coreClient.analysisNode.getMany({
+            filter: { analysis_id: analysis.id },
+            page,
+        }));
 
         if (analysisNodes.length === 0) {
             // todo: custom error
             throw BuilderError.notFound();
         }
 
-        const { data: nodes } = await this.coreClient.node.getMany({
+        const nodes = await getManyAll((page) => this.coreClient.node.getMany({
             filter: { id: analysisNodes.map((analysisNode) => analysisNode.node_id) },
             relations: { registry_project: true },
-        });
+            page,
+        }));
 
         // -----------------------------------------------------------------------------------
 

--- a/apps/server-core-worker/src/app/components/constants.ts
+++ b/apps/server-core-worker/src/app/components/constants.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * An in-progress build/distribution whose analysis row has not been touched
+ * for longer than this is considered orphaned (e.g. the worker died mid-process):
+ * the check command then yields a FAILED verdict so the process can be retriggered.
+ */
+export const ANALYSIS_PROCESS_STALE_THRESHOLD_MS = 15 * 60 * 1000;

--- a/apps/server-core-worker/src/app/components/helpers.ts
+++ b/apps/server-core-worker/src/app/components/helpers.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ANALYSIS_PROCESS_STALE_THRESHOLD_MS } from './constants';
+
+/**
+ * Determine if an in-progress analysis process (build/distribution) is stale,
+ * i.e. its entity has not been updated for longer than the given threshold.
+ * Progress events touch the entity, so a recently updated row means the
+ * process is still alive.
+ *
+ * @param updatedAt
+ * @param thresholdMs
+ */
+export function isAnalysisProcessStale(
+    updatedAt: Date | string,
+    thresholdMs: number = ANALYSIS_PROCESS_STALE_THRESHOLD_MS,
+): boolean {
+    const updatedAtMs = new Date(updatedAt).getTime();
+    if (Number.isNaN(updatedAtMs)) {
+        return false;
+    }
+
+    return Date.now() - updatedAtMs > thresholdMs;
+}

--- a/apps/server-core-worker/test/unit/adapters/docker-error.spec.ts
+++ b/apps/server-core-worker/test/unit/adapters/docker-error.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    isDockerDistributionImageMissingError,
+    isDockerErrorWithStatusCode,
+    isDockerNotFoundError,
+} from '../../../src/adapters/docker/error';
+
+function createDockerError(statusCode?: number): Error {
+    const error = new Error('(HTTP code) message');
+    if (typeof statusCode !== 'undefined') {
+        Object.assign(error, { statusCode });
+    }
+    return error;
+}
+
+describe('isDockerErrorWithStatusCode', () => {
+    it('should match an error carrying the given status code', () => {
+        expect(isDockerErrorWithStatusCode(createDockerError(404), 404)).toBe(true);
+        expect(isDockerErrorWithStatusCode(createDockerError(500), 404)).toBe(false);
+    });
+
+    it('should not match connection errors without a status code', () => {
+        expect(isDockerErrorWithStatusCode(createDockerError(), 404)).toBe(false);
+    });
+
+    it('should not match non-error values', () => {
+        expect(isDockerErrorWithStatusCode({ statusCode: 404 }, 404)).toBe(false);
+        expect(isDockerErrorWithStatusCode(undefined, 404)).toBe(false);
+    });
+});
+
+describe('isDockerNotFoundError', () => {
+    it('should match 404 only', () => {
+        expect(isDockerNotFoundError(createDockerError(404))).toBe(true);
+        expect(isDockerNotFoundError(createDockerError(401))).toBe(false);
+        expect(isDockerNotFoundError(createDockerError())).toBe(false);
+    });
+});
+
+describe('isDockerDistributionImageMissingError', () => {
+    it('should match 401 (docker api: no image found or failed authentication)', () => {
+        expect(isDockerDistributionImageMissingError(createDockerError(401))).toBe(true);
+    });
+
+    it('should match 404 defensively', () => {
+        expect(isDockerDistributionImageMissingError(createDockerError(404))).toBe(true);
+    });
+
+    it('should not match server or connection failures', () => {
+        expect(isDockerDistributionImageMissingError(createDockerError(500))).toBe(false);
+        expect(isDockerDistributionImageMissingError(createDockerError())).toBe(false);
+    });
+});

--- a/apps/server-core-worker/test/unit/components/helpers.spec.ts
+++ b/apps/server-core-worker/test/unit/components/helpers.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ANALYSIS_PROCESS_STALE_THRESHOLD_MS } from '../../../src/app/components/constants';
+import { isAnalysisProcessStale } from '../../../src/app/components/helpers';
+
+describe('isAnalysisProcessStale', () => {
+    it('should not be stale when updated within the threshold', () => {
+        const updatedAt = new Date(Date.now() - 60 * 1000);
+
+        expect(isAnalysisProcessStale(updatedAt)).toBe(false);
+    });
+
+    it('should be stale when not updated for longer than the threshold', () => {
+        const updatedAt = new Date(Date.now() - ANALYSIS_PROCESS_STALE_THRESHOLD_MS - 1000);
+
+        expect(isAnalysisProcessStale(updatedAt)).toBe(true);
+    });
+
+    it('should accept an ISO string timestamp (HTTP payloads)', () => {
+        const updatedAt = new Date(Date.now() - ANALYSIS_PROCESS_STALE_THRESHOLD_MS - 1000).toISOString();
+
+        expect(isAnalysisProcessStale(updatedAt)).toBe(true);
+    });
+
+    it('should respect a custom threshold', () => {
+        const updatedAt = new Date(Date.now() - 5 * 1000);
+
+        expect(isAnalysisProcessStale(updatedAt, 1000)).toBe(true);
+        expect(isAnalysisProcessStale(updatedAt, 60 * 1000)).toBe(false);
+    });
+
+    it('should not be stale for an invalid timestamp', () => {
+        expect(isAnalysisProcessStale('not-a-date')).toBe(false);
+    });
+});

--- a/apps/server-core/src/app/aggregators/worker/analysis-builder/handler.ts
+++ b/apps/server-core/src/app/aggregators/worker/analysis-builder/handler.ts
@@ -49,7 +49,10 @@ export async function handleAnalysisBuilderEvent(
             }
             break;
         }
-        case AnalysisBuilderEvent.CHECK_FAILED:
+        case AnalysisBuilderEvent.CHECK_FAILED: {
+            // failure of the check itself says nothing about the build outcome
+            return;
+        }
         case AnalysisBuilderEvent.EXECUTION_FAILED: {
             entity.build_status = ProcessStatus.FAILED;
             break;
@@ -66,16 +69,25 @@ export async function handleAnalysisBuilderEvent(
         }
         case AnalysisBuilderEvent.CHECK_FINISHED: {
             const temp = value as AnalysisBuilderCheckFinishedPayload;
-            if (temp.status) {
-                entity.build_progress = temp.status === ProcessStatus.EXECUTED ?
-                    100 :
-                    0;
+            if (!temp.status) {
+                return;
             }
 
-            entity.build_hash = temp.hash ?? null;
-            entity.build_os = temp.os ?? null;
-            entity.build_size = temp.size ?? null;
-            entity.build_status = temp.status || null;
+            entity.build_status = temp.status;
+
+            if (temp.status === ProcessStatus.EXECUTED) {
+                entity.build_progress = 100;
+                entity.build_hash = temp.hash ?? entity.build_hash;
+                entity.build_os = temp.os ?? entity.build_os;
+                entity.build_size = temp.size ?? entity.build_size;
+            } else if (temp.status === ProcessStatus.FAILED) {
+                // the image is verifiably gone (e.g. docker daemon data loss) —
+                // reset the build artifacts so the build can be retriggered.
+                entity.build_progress = 0;
+                entity.build_hash = temp.hash ?? null;
+                entity.build_os = temp.os ?? null;
+                entity.build_size = temp.size ?? null;
+            }
         }
     }
 

--- a/apps/server-core/src/app/aggregators/worker/analysis-distributor/handler.ts
+++ b/apps/server-core/src/app/aggregators/worker/analysis-distributor/handler.ts
@@ -47,7 +47,10 @@ export async function handleAnalysisDistributorEvent(
             }
             break;
         }
-        case AnalysisDistributorEvent.CHECK_FAILED:
+        case AnalysisDistributorEvent.CHECK_FAILED: {
+            // failure of the check itself says nothing about the distribution outcome
+            return;
+        }
         case AnalysisDistributorEvent.EXECUTION_FAILED: {
             entity.distribution_status = ProcessStatus.FAILED;
             break;
@@ -59,13 +62,17 @@ export async function handleAnalysisDistributorEvent(
         }
         case AnalysisDistributorEvent.CHECK_FINISHED: {
             const temp = value as AnalysisDistributorCheckFinishedPayload;
-            if (temp.status) {
-                entity.distribution_progress = temp.status === ProcessStatus.EXECUTED ?
-                    100 :
-                    0;
+            if (!temp.status) {
+                return;
             }
 
-            entity.distribution_status = temp.status || null;
+            entity.distribution_status = temp.status;
+
+            if (temp.status === ProcessStatus.EXECUTED) {
+                entity.distribution_progress = 100;
+            } else if (temp.status === ProcessStatus.FAILED) {
+                entity.distribution_progress = 0;
+            }
         }
     }
 

--- a/apps/server-core/test/unit/app/aggregators/worker-analysis.spec.ts
+++ b/apps/server-core/test/unit/app/aggregators/worker-analysis.spec.ts
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { faker } from '@faker-js/faker';
+import { AnalysisBuilderCommandChecker } from '@privateaim/core-kit';
+import { ProcessStatus } from '@privateaim/kit';
+import type {
+    AnalysisBuilderCheckFinishedPayload,
+    AnalysisBuilderEventMap,
+    AnalysisDistributorCheckFinishedPayload,
+    AnalysisDistributorEventMap,
+} from '@privateaim/server-core-worker-kit';
+import {
+    AnalysisBuilderEvent,
+    AnalysisDistributorEvent,
+} from '@privateaim/server-core-worker-kit';
+import type { ComponentEventMap, ComponentHandlerContext } from '@privateaim/server-kit';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { DataSource } from 'typeorm';
+import { AnalysisEntity, ProjectEntity } from '../../../../src/adapters/database/index.ts';
+import { DatabaseInjectionKey } from '../../../../src/app/modules/database/index.ts';
+import { handleAnalysisBuilderEvent } from '../../../../src/app/aggregators/worker/analysis-builder/handler.ts';
+import { handleAnalysisDistributorEvent } from '../../../../src/app/aggregators/worker/analysis-distributor/handler.ts';
+import { createTestDatabaseApplication } from '../../../app';
+
+function createContext<
+    EventMap extends ComponentEventMap,
+>(key: keyof EventMap & string): ComponentHandlerContext<EventMap> {
+    return {
+        key,
+        metadata: {},
+        handle: async () => {},
+    };
+}
+
+describe('worker analysis aggregators', () => {
+    const suite = createTestDatabaseApplication();
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        await suite.setup();
+        dataSource = suite.container.resolve(DatabaseInjectionKey.DataSource);
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    async function createAnalysis(overrides: Partial<AnalysisEntity> = {}): Promise<AnalysisEntity> {
+        const projectRepository = dataSource.getRepository(ProjectEntity);
+        const project = await projectRepository.save(projectRepository.create({
+            name: faker.string.alpha({ length: 16, casing: 'lower' }),
+            realm_id: faker.string.uuid(),
+        }));
+
+        const repository = dataSource.getRepository(AnalysisEntity);
+        return repository.save(repository.create({
+            name: faker.string.alpha({ length: 16, casing: 'lower' }),
+            realm_id: project.realm_id,
+            project_id: project.id,
+            ...overrides,
+        }));
+    }
+
+    async function findAnalysis(id: string): Promise<AnalysisEntity> {
+        return dataSource.getRepository(AnalysisEntity).findOneByOrFail({ id });
+    }
+
+    describe('analysis-builder', () => {
+        it('should apply build metadata on CHECK_FINISHED with status EXECUTED', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.STARTED,
+                build_progress: 40,
+            });
+
+            const payload: AnalysisBuilderCheckFinishedPayload = {
+                id: analysis.id,
+                status: ProcessStatus.EXECUTED,
+                hash: 'sha256:abc',
+                os: 'linux',
+                size: 1024,
+            };
+
+            await handleAnalysisBuilderEvent(
+                payload,
+                createContext<AnalysisBuilderEventMap>(AnalysisBuilderEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.build_status).toBe(ProcessStatus.EXECUTED);
+            expect(entity.build_progress).toBe(100);
+            expect(entity.build_hash).toBe('sha256:abc');
+            expect(entity.build_os).toBe('linux');
+            expect(entity.build_size).toBe(1024);
+        });
+
+        it('should keep build metadata and progress on CHECK_FINISHED with in-progress status', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.STARTED,
+                build_progress: 40,
+                build_hash: 'sha256:previous',
+                build_os: 'linux',
+                build_size: 512,
+            });
+
+            const payload: AnalysisBuilderCheckFinishedPayload = {
+                id: analysis.id,
+                status: ProcessStatus.STARTED,
+            };
+
+            await handleAnalysisBuilderEvent(
+                payload,
+                createContext<AnalysisBuilderEventMap>(AnalysisBuilderEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.build_status).toBe(ProcessStatus.STARTED);
+            expect(entity.build_progress).toBe(40);
+            expect(entity.build_hash).toBe('sha256:previous');
+            expect(entity.build_os).toBe('linux');
+            expect(entity.build_size).toBe(512);
+        });
+
+        it('should reset build artifacts on CHECK_FINISHED with status FAILED (data loss recovery)', async () => {
+            const analysis = await createAnalysis({
+                configuration_locked: true,
+                build_nodes_valid: true,
+                build_status: ProcessStatus.EXECUTED,
+                build_progress: 100,
+                build_hash: 'sha256:lost',
+                build_os: 'linux',
+                build_size: 512,
+            });
+
+            const payload: AnalysisBuilderCheckFinishedPayload = {
+                id: analysis.id,
+                status: ProcessStatus.FAILED,
+            };
+
+            await handleAnalysisBuilderEvent(
+                payload,
+                createContext<AnalysisBuilderEventMap>(AnalysisBuilderEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.build_status).toBe(ProcessStatus.FAILED);
+            expect(entity.build_progress).toBe(0);
+            expect(entity.build_hash).toBeNull();
+            expect(entity.build_os).toBeNull();
+            expect(entity.build_size).toBeNull();
+
+            // the analysis must be rebuildable again after the reset
+            expect(() => AnalysisBuilderCommandChecker.canStart(entity)).not.toThrow();
+        });
+
+        it('should not modify the entity on CHECK_FINISHED without status', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.STARTING,
+                build_hash: 'sha256:previous',
+            });
+
+            const payload: AnalysisBuilderCheckFinishedPayload = { id: analysis.id };
+
+            await handleAnalysisBuilderEvent(
+                payload,
+                createContext<AnalysisBuilderEventMap>(AnalysisBuilderEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.build_status).toBe(ProcessStatus.STARTING);
+            expect(entity.build_hash).toBe('sha256:previous');
+        });
+
+        it('should not mark the build as FAILED on CHECK_FAILED', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.STARTED,
+                build_progress: 40,
+            });
+
+            await handleAnalysisBuilderEvent(
+                { id: analysis.id },
+                createContext<AnalysisBuilderEventMap>(AnalysisBuilderEvent.CHECK_FAILED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.build_status).toBe(ProcessStatus.STARTED);
+            expect(entity.build_progress).toBe(40);
+        });
+
+        it('should mark the build as FAILED on EXECUTION_FAILED', async () => {
+            const analysis = await createAnalysis({ build_status: ProcessStatus.STARTED });
+
+            await handleAnalysisBuilderEvent(
+                { id: analysis.id },
+                createContext<AnalysisBuilderEventMap>(AnalysisBuilderEvent.EXECUTION_FAILED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.build_status).toBe(ProcessStatus.FAILED);
+        });
+    });
+
+    describe('analysis-distributor', () => {
+        it('should mark the distribution as EXECUTED on CHECK_FINISHED with status EXECUTED', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTED,
+                distribution_progress: 40,
+            });
+
+            const payload: AnalysisDistributorCheckFinishedPayload = {
+                id: analysis.id,
+                status: ProcessStatus.EXECUTED,
+            };
+
+            await handleAnalysisDistributorEvent(
+                payload,
+                createContext<AnalysisDistributorEventMap>(AnalysisDistributorEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.distribution_status).toBe(ProcessStatus.EXECUTED);
+            expect(entity.distribution_progress).toBe(100);
+        });
+
+        it('should mark the distribution as FAILED on CHECK_FINISHED with status FAILED', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTED,
+                distribution_progress: 40,
+            });
+
+            const payload: AnalysisDistributorCheckFinishedPayload = {
+                id: analysis.id,
+                status: ProcessStatus.FAILED,
+            };
+
+            await handleAnalysisDistributorEvent(
+                payload,
+                createContext<AnalysisDistributorEventMap>(AnalysisDistributorEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.distribution_status).toBe(ProcessStatus.FAILED);
+            expect(entity.distribution_progress).toBe(0);
+        });
+
+        it('should keep progress on CHECK_FINISHED with in-progress status', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTED,
+                distribution_progress: 40,
+            });
+
+            const payload: AnalysisDistributorCheckFinishedPayload = {
+                id: analysis.id,
+                status: ProcessStatus.STARTED,
+            };
+
+            await handleAnalysisDistributorEvent(
+                payload,
+                createContext<AnalysisDistributorEventMap>(AnalysisDistributorEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.distribution_status).toBe(ProcessStatus.STARTED);
+            expect(entity.distribution_progress).toBe(40);
+        });
+
+        it('should not modify the entity on CHECK_FINISHED without status', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTING,
+            });
+
+            const payload: AnalysisDistributorCheckFinishedPayload = { id: analysis.id };
+
+            await handleAnalysisDistributorEvent(
+                payload,
+                createContext<AnalysisDistributorEventMap>(AnalysisDistributorEvent.CHECK_FINISHED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.distribution_status).toBe(ProcessStatus.STARTING);
+        });
+
+        it('should not mark the distribution as FAILED on CHECK_FAILED', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTED,
+                distribution_progress: 40,
+            });
+
+            await handleAnalysisDistributorEvent(
+                { id: analysis.id },
+                createContext<AnalysisDistributorEventMap>(AnalysisDistributorEvent.CHECK_FAILED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.distribution_status).toBe(ProcessStatus.STARTED);
+            expect(entity.distribution_progress).toBe(40);
+        });
+
+        it('should mark the distribution as FAILED on EXECUTION_FAILED', async () => {
+            const analysis = await createAnalysis({
+                build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTED,
+            });
+
+            await handleAnalysisDistributorEvent(
+                { id: analysis.id },
+                createContext<AnalysisDistributorEventMap>(AnalysisDistributorEvent.EXECUTION_FAILED),
+                dataSource,
+            );
+
+            const entity = await findAnalysis(analysis.id);
+            expect(entity.distribution_status).toBe(ProcessStatus.FAILED);
+        });
+    });
+});

--- a/apps/server-core/test/unit/core/entities/analysis/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/analysis/service.spec.ts
@@ -593,6 +593,7 @@ describe('AnalysisService', () => {
             analysisRepository.seed(createFullAnalysis({
                 configuration_locked: true,
                 build_status: ProcessStatus.EXECUTED,
+                distribution_status: ProcessStatus.STARTED,
             }));
 
             await service.executeCommand(

--- a/apps/server-core/test/unit/core/services/analysis-builder.spec.ts
+++ b/apps/server-core/test/unit/core/services/analysis-builder.spec.ts
@@ -159,11 +159,14 @@ describe('AnalysisBuilder', () => {
             await expect(builder.check(analysis)).rejects.toThrow(AnalysisError);
         });
 
-        it('should throw when build already EXECUTED', async () => {
+        it('should dispatch check call for EXECUTED build (reconciliation after data loss)', async () => {
             const analysis = createFullAnalysis({ configuration_locked: true, build_status: ProcessStatus.EXECUTED });
             repository.seed(analysis);
 
-            await expect(builder.check(analysis)).rejects.toThrow(AnalysisError);
+            const result = await builder.check(analysis);
+
+            expect(result.id).toBe('analysis-1');
+            expect(caller.getCallsFor('callCheck')).toHaveLength(1);
         });
     });
 });

--- a/apps/server-core/test/unit/core/services/analysis-distributor.spec.ts
+++ b/apps/server-core/test/unit/core/services/analysis-distributor.spec.ts
@@ -171,7 +171,7 @@ describe('AnalysisDistributor', () => {
 
     describe('check', () => {
         it('should dispatch check call', async () => {
-            const analysis = seedBuiltAnalysis();
+            const analysis = seedBuiltAnalysis({ distribution_status: ProcessStatus.STARTED });
 
             const result = await distributor.check(analysis);
 
@@ -180,7 +180,7 @@ describe('AnalysisDistributor', () => {
         });
 
         it('should resolve entity by string ID', async () => {
-            seedBuiltAnalysis();
+            seedBuiltAnalysis({ distribution_status: ProcessStatus.STARTED });
 
             const result = await distributor.check('analysis-1');
             expect(result.id).toBe('analysis-1');
@@ -200,6 +200,21 @@ describe('AnalysisDistributor', () => {
             const analysis = seedBuiltAnalysis({ build_status: ProcessStatus.FAILED });
 
             await expect(distributor.check(analysis)).rejects.toThrow(AnalysisError);
+        });
+
+        it('should throw when distribution not initialized', async () => {
+            const analysis = seedBuiltAnalysis();
+
+            await expect(distributor.check(analysis)).rejects.toThrow(AnalysisError);
+        });
+
+        it('should dispatch check call for EXECUTED distribution (reconciliation after data loss)', async () => {
+            const analysis = seedBuiltAnalysis({ distribution_status: ProcessStatus.EXECUTED });
+
+            const result = await distributor.check(analysis);
+
+            expect(result.id).toBe('analysis-1');
+            expect(caller.getCallsFor('callCheck')).toHaveLength(1);
         });
     });
 });

--- a/docs/src/reference/core/core-http-kit.md
+++ b/docs/src/reference/core/core-http-kit.md
@@ -41,6 +41,20 @@ await client.analysis.update(analysisId, { name: 'Updated' });
 await client.analysis.delete(analysisId);
 ```
 
+### Exhaustive Collections
+
+`getMany` returns a single page; the server caps the page size (default `maxLimit: 50`).
+Use `getManyAll` to follow the pagination until every record is retrieved:
+
+```typescript
+import { getManyAll } from '@privateaim/core-http-kit';
+
+const analysisNodes = await getManyAll((page) => client.analysisNode.getMany({
+    filter: { analysis_id: analysisId },
+    page,
+}));
+```
+
 ### With Authentication
 
 ```typescript
@@ -58,6 +72,7 @@ const client = new HTTPClient({
 |--------|-------------|
 | `client` | `HTTPClient` class with typed domain API methods |
 | `domains` | Domain-specific request/response types |
+| `getManyAll` | Helper that fetches a resource collection exhaustively across all pages |
 
 ### Client Methods
 

--- a/packages/core-http-kit/package.json
+++ b/packages/core-http-kit/package.json
@@ -20,14 +20,16 @@
     },
     "scripts": {
         "build": "rimraf ./dist && tsdown",
-        "build-watch": "rimraf ./dist && tsc -p tsconfig.build.json --watch"
+        "build-watch": "rimraf ./dist && tsc -p tsconfig.build.json --watch",
+        "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts"
     },
     "devDependencies": {
         "@authup/kit": "^1.0.0-beta.42",
         "@privateaim/core-kit": "^0.10.1",
         "@privateaim/telemetry-kit": "^0.10.1",
         "hapic": "^2.8.2",
-        "rapiq": "^0.9.0"
+        "rapiq": "^0.9.0",
+        "vitest": "^4.1.7"
     },
     "peerDependencies": {
         "@authup/kit": "^1.0.0-beta.42",

--- a/packages/core-http-kit/src/domains/helpers.ts
+++ b/packages/core-http-kit/src/domains/helpers.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { CollectionResourceFetcher } from './types-base';
+
+const PAGE_SIZE = 50;
+
+/**
+ * Fetch a resource collection exhaustively, following pagination until
+ * every record is retrieved. The server caps the page size (maxLimit),
+ * so a single getMany call never guarantees the full collection.
+ *
+ * @param fetch
+ */
+export async function getManyAll<T>(fetch: CollectionResourceFetcher<T>): Promise<T[]> {
+    const items : T[] = [];
+
+    let offset = 0;
+    let total = 1;
+
+    while (offset < total) {
+        const { data, meta } = await fetch({ limit: PAGE_SIZE, offset });
+
+        items.push(...data);
+
+        if (data.length === 0) {
+            break;
+        }
+
+        offset += data.length;
+        total = meta.total;
+    }
+
+    return items;
+}

--- a/packages/core-http-kit/src/domains/index.ts
+++ b/packages/core-http-kit/src/domains/index.ts
@@ -21,4 +21,5 @@ export * from './analysis-node-event';
 export * from './analysis-node-log';
 export * from './analysis-permission';
 export * from './service';
+export * from './helpers';
 export * from './types-base';

--- a/packages/core-http-kit/src/domains/types-base.ts
+++ b/packages/core-http-kit/src/domains/types-base.ts
@@ -18,6 +18,15 @@ export type CollectionResourceResponse<R> = {
     }
 };
 
+export type CollectionResourcePage = {
+    limit: number,
+    offset: number
+};
+
+export type CollectionResourceFetcher<R> = (
+    page: CollectionResourcePage,
+) => Promise<CollectionResourceResponse<R>>;
+
 export type DomainEntityWithID = {
     [key: string]: any,
     id: any

--- a/packages/core-http-kit/test/unit/get-many-all.spec.ts
+++ b/packages/core-http-kit/test/unit/get-many-all.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { CollectionResourcePage, CollectionResourceResponse } from '../../src/domains/types-base';
+import { getManyAll } from '../../src/domains/helpers';
+
+type Item = { id: number };
+
+class FakeCollectionAPI {
+    protected items: Item[];
+
+    protected maxLimit: number;
+
+    public pages: CollectionResourcePage[] = [];
+
+    constructor(total: number, maxLimit: number) {
+        this.items = Array.from({ length: total }, (_, i) => ({ id: i }));
+        this.maxLimit = maxLimit;
+    }
+
+    async getMany(page: CollectionResourcePage): Promise<CollectionResourceResponse<Item>> {
+        this.pages.push(page);
+
+        const limit = Math.min(page.limit, this.maxLimit);
+        const data = this.items.slice(page.offset, page.offset + limit);
+
+        return {
+            data,
+            meta: {
+                limit,
+                offset: page.offset,
+                total: this.items.length,
+            },
+        };
+    }
+}
+
+describe('getManyAll', () => {
+    it('should collect all records across multiple pages', async () => {
+        const api = new FakeCollectionAPI(120, 50);
+
+        const items = await getManyAll((page) => api.getMany(page));
+
+        expect(items).toHaveLength(120);
+        expect(items.map((item) => item.id)).toEqual(Array.from({ length: 120 }, (_, i) => i));
+        expect(api.pages).toHaveLength(3);
+    });
+
+    it('should collect a collection smaller than one page', async () => {
+        const api = new FakeCollectionAPI(3, 50);
+
+        const items = await getManyAll((page) => api.getMany(page));
+
+        expect(items).toHaveLength(3);
+        expect(api.pages).toHaveLength(1);
+    });
+
+    it('should handle an empty collection', async () => {
+        const api = new FakeCollectionAPI(0, 50);
+
+        const items = await getManyAll((page) => api.getMany(page));
+
+        expect(items).toHaveLength(0);
+        expect(api.pages).toHaveLength(1);
+    });
+
+    it('should respect a server page cap smaller than the requested limit', async () => {
+        const api = new FakeCollectionAPI(25, 10);
+
+        const items = await getManyAll((page) => api.getMany(page));
+
+        expect(items).toHaveLength(25);
+        expect(api.pages).toHaveLength(3);
+    });
+
+    it('should terminate when the server returns an exact page boundary', async () => {
+        const api = new FakeCollectionAPI(100, 50);
+
+        const items = await getManyAll((page) => api.getMany(page));
+
+        expect(items).toHaveLength(100);
+        expect(api.pages).toHaveLength(2);
+    });
+});

--- a/packages/core-http-kit/test/vitest.config.ts
+++ b/packages/core-http-kit/test/vitest.config.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: { include: ['test/unit/**/*.spec.ts'] },
+    plugins: [swc.vite()],
+});

--- a/packages/core-kit/src/domains/analysis/helpers/builder.ts
+++ b/packages/core-kit/src/domains/analysis/helpers/builder.ts
@@ -52,9 +52,8 @@ export class AnalysisBuilderCommandChecker {
             throw new AnalysisError('The analysis build process has not been initialized.');
         }
 
-        if (entity.build_status === ProcessStatus.EXECUTED) {
-            throw new AnalysisError('The analysis build process has already been successfully completed.');
-        }
+        // EXECUTED is checkable on purpose: it reconciles the recorded state
+        // with the docker daemon after data loss (image gone -> FAILED -> rebuildable).
 
         // todo: check time
     }

--- a/packages/core-kit/src/domains/analysis/helpers/distributor.ts
+++ b/packages/core-kit/src/domains/analysis/helpers/distributor.ts
@@ -50,6 +50,13 @@ export class AnalysisDistributorCommandChecker {
             throw new AnalysisError('The analysis build process has not been finished.');
         }
 
+        if (!entity.distribution_status) {
+            throw new AnalysisError('The analysis distribution process has not been initialized.');
+        }
+
+        // EXECUTED is checkable on purpose: it reconciles the recorded state
+        // with the registry after data loss (images gone -> FAILED -> redistributable).
+
         // todo: check time
     }
 }

--- a/packages/core-kit/test/unit/analysis-command-checkers.spec.ts
+++ b/packages/core-kit/test/unit/analysis-command-checkers.spec.ts
@@ -230,9 +230,9 @@ describe('AnalysisBuilderCommandChecker', () => {
             expect(() => AnalysisBuilderCommandChecker.canCheck(entity)).toThrow(AnalysisError);
         });
 
-        it('should throw when build already EXECUTED', () => {
+        it('should allow when build EXECUTED (reconciliation after data loss)', () => {
             const entity = createBaseAnalysis({ configuration_locked: true, build_status: ProcessStatus.EXECUTED });
-            expect(() => AnalysisBuilderCommandChecker.canCheck(entity)).toThrow(AnalysisError);
+            expect(() => AnalysisBuilderCommandChecker.canCheck(entity)).not.toThrow();
         });
 
         it('should allow when build STARTED', () => {
@@ -320,8 +320,28 @@ describe('AnalysisDistributorCommandChecker', () => {
     });
 
     describe('canCheck', () => {
-        it('should allow when build EXECUTED', () => {
-            const entity = createBaseAnalysis({ build_status: ProcessStatus.EXECUTED });
+        it('should allow when build EXECUTED and distribution in progress', () => {
+            const entity = createBaseAnalysis({ build_status: ProcessStatus.EXECUTED, distribution_status: ProcessStatus.STARTED });
+            expect(() => AnalysisDistributorCommandChecker.canCheck(entity)).not.toThrow();
+        });
+
+        it('should allow when distribution STARTING', () => {
+            const entity = createBaseAnalysis({ build_status: ProcessStatus.EXECUTED, distribution_status: ProcessStatus.STARTING });
+            expect(() => AnalysisDistributorCommandChecker.canCheck(entity)).not.toThrow();
+        });
+
+        it('should allow when distribution FAILED', () => {
+            const entity = createBaseAnalysis({ build_status: ProcessStatus.EXECUTED, distribution_status: ProcessStatus.FAILED });
+            expect(() => AnalysisDistributorCommandChecker.canCheck(entity)).not.toThrow();
+        });
+
+        it('should throw when distribution not initialized', () => {
+            const entity = createBaseAnalysis({ build_status: ProcessStatus.EXECUTED, distribution_status: null });
+            expect(() => AnalysisDistributorCommandChecker.canCheck(entity)).toThrow(AnalysisError);
+        });
+
+        it('should allow when distribution EXECUTED (reconciliation after data loss)', () => {
+            const entity = createBaseAnalysis({ build_status: ProcessStatus.EXECUTED, distribution_status: ProcessStatus.EXECUTED });
             expect(() => AnalysisDistributorCommandChecker.canCheck(entity)).not.toThrow();
         });
 


### PR DESCRIPTION
## Summary

The analysis builder/distributor `check` commands were broken as a reconciliation mechanism: wrong status fields, partial node coverage, destructive aggregation, and no recovery path after docker daemon / registry data loss. This PR makes the check flow the reliable way to re-sync recorded state with reality.

### Worker (`server-core-worker`)

- **Distributor check**: report `distribution_status` (previously `build_status` — a failed pull mid-distribution could mark the distribution as *executed*), verify **every** node instead of one, and use a registry **manifest lookup** (`/distribution`) instead of pulling full images (no transfer, no disk usage, no cleanup needed).
- **Builder check**: distinguish docker **404** (image verifiably gone) from daemon failures (rethrown → `CHECK_FAILED`, state untouched); fail-safe handling of a missing local image when a distribution explains its absence; check failures are now logged.
- **Staleness**: an in-progress build/distribution whose entity hasn't been touched for **15 minutes** is treated as orphaned by the check (worker died mid-process) and yields a `FAILED` verdict — previously such analyses were stuck forever.
- New `isDockerNotFoundError` + `isAnalysisProcessStale` helpers.

### Aggregation (`server-core`)

- `CHECK_FINISHED` only overwrites fields the payload actually carries (no more wiping `build_hash/os/size` or statuses to `null`).
- A `FAILED` verdict resets build artifacts so `BUILD_START` becomes legal again (data-loss recovery).
- `CHECK_FAILED` (the check itself errored) no longer marks the build/distribution as failed.

### Command checkers (`core-kit`)

- `canCheck` now **allows** `EXECUTED` processes — checking is the reconciliation path after data loss (previously a successfully built analysis with lost images was unrecoverable: no command was runnable).
- Distributor `canCheck` requires an initialized distribution (prevents `registry.getOne(null)` crashes).

### Pagination (`core-http-kit`)

- New `getManyAll` helper fetches collections exhaustively across pages. Applied to all capped `getMany` call sites in the worker — the server's default `maxLimit: 50` previously meant distribution check/execute silently covered only the first 50 nodes, and code packing failed beyond 50 bucket files.

### Tests & docs

- New: aggregator handler suite (12 tests, incl. full data-loss recovery chain), `getManyAll` suite (5), staleness helper suite (5); `core-http-kit` got test infra.
- Updated command-checker and service specs to the new semantics.
- `core-http-kit` reference docs document `getManyAll`.

## Test plan

- `npx nx run-many -t test -p @privateaim/core-http-kit @privateaim/core-kit @privateaim/server-core @privateaim/server-core-worker` — all green (SQLite).
- Manual smoke of the recovery chain still recommended against a real daemon: build → remove image → `BUILD_CHECK` → status `FAILED`, artifacts reset → rebuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pagination support for exhaustive collection retrieval across large datasets
  * Enhanced analysis check handlers with improved Docker image validation and detailed error logging
  * Added detection for stale analysis processes to improve cleanup and reconciliation

* **Bug Fixes**
  * Improved error handling for Docker operations
  * Better status reconciliation for analyses after potential data loss scenarios

* **Documentation**
  * Updated pagination guidance with practical examples

* **Tests**
  * Comprehensive test coverage for stale process detection and pagination helpers
  * Added aggregator event handler persistence tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->