### PR TITLE
fix(client): entrypoint pagination + display_name in views

### DIFF
--- a/apps/client-ui/components/layout/header.vue
+++ b/apps/client-ui/components/layout/header.vue
@@ -6,6 +6,7 @@
   -->
 <script lang="ts">
 import { injectStore, storeToRefs } from '@authup/client-web-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { VCGravatar } from '@vuecs/gravatar';
 import { VCNavItems } from '@vuecs/navigation';
 import { BCollapse } from 'bootstrap-vue-next';
@@ -16,6 +17,7 @@ import { defineNuxtComponent } from '#app';
 export default defineNuxtComponent({
     components: {
         BCollapse,
+        FDisplayName,
         VCGravatar,
         VCNavItems,
     },
@@ -86,7 +88,12 @@ export default defineNuxtComponent({
                                 :to="'/users/'+user.id"
                             >
                                 <VCGravatar :email="user.email ? user.email : ''" />
-                                <span>{{ user.display_name ? user.display_name : user.name }}</span>
+                                <span>
+                                    <FDisplayName
+                                        :name="user.name"
+                                        :display-name="user.display_name"
+                                    />
+                                </span>
                             </nuxt-link>
                         </li>
                         <li class="vc-nav-item">

--- a/apps/client-ui/pages/admin/clients/[id].vue
+++ b/apps/client-ui/pages/admin/clients/[id].vue
@@ -2,6 +2,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { Client } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { extendObject } from '@authup/kit';
 import { type Ref, defineComponent } from 'vue';
 import { ref } from 'vue';
@@ -15,6 +16,7 @@ import {
 import { LayoutKey } from '../../../config/layout';
 
 export default defineComponent({
+    components: { FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.REQUIRED_LOGGED_IN]: true,
@@ -91,7 +93,10 @@ export default defineComponent({
 <template>
     <div>
         <h1 class="title no-border mb-3">
-            <i class="fa-solid fa-ghost me-1" /> {{ entity.name }}
+            <i class="fa-solid fa-ghost me-1" /> <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">Details</span>
         </h1>
         <div class="mb-2">

--- a/apps/client-ui/pages/admin/clients/[id]/url.vue
+++ b/apps/client-ui/pages/admin/clients/[id]/url.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
 import { AClientScopes } from '@authup/client-web-kit';
 import type { Client, ClientScope } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import {
-    VCFormInput, 
+    VCFormInput,
     VCFormInputCheckbox,
 } from '@vuecs/form-controls';
 import type { BuildInput } from 'rapiq';
@@ -13,9 +14,10 @@ import { defineNuxtComponent } from '#imports';
 
 export default defineNuxtComponent({
     components: {
-        VCFormInput, 
-        VCFormInputCheckbox, 
-        AClientScopes, 
+        FDisplayName,
+        VCFormInput,
+        VCFormInputCheckbox,
+        AClientScopes,
     },
     props: {
         entity: {
@@ -91,7 +93,10 @@ export default defineNuxtComponent({
                 >
                     <template #label="iProps">
                         <label :for="iProps.id">
-                            {{ props.data.scope.name }}
+                            <FDisplayName
+                                :name="props.data.scope.name"
+                                :display-name="props.data.scope.display_name"
+                            />
                         </label>
                     </template>
                 </VCFormInputCheckbox>

--- a/apps/client-ui/pages/admin/clients/index/index.vue
+++ b/apps/client-ui/pages/admin/clients/index/index.vue
@@ -14,6 +14,7 @@ import {
 } from '@authup/client-web-kit';
 import type { Client } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 
 import type { BuildInput } from 'rapiq';
 import { defineComponent } from 'vue';
@@ -27,6 +28,7 @@ export default defineComponent({
         AEntityDelete,
         AClients,
         AUser,
+        FDisplayName,
     },
     emits: ['deleted'],
     setup(props, { emit }) {
@@ -123,6 +125,12 @@ export default defineComponent({
                 head-variant="'dark'"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(active)="data">
                     <i
                         class="fas"
@@ -160,7 +168,10 @@ export default defineComponent({
                     <template v-if="data.item.user_id">
                         <AUser :entity-id="data.item.user_id">
                             <template #default="user">
-                                {{ user.data.name }}
+                                <FDisplayName
+                                    :name="user.data.name"
+                                    :display-name="user.data.display_name"
+                                />
                             </template>
                             <template #error>
                                 -

--- a/apps/client-ui/pages/admin/identity-providers/[id].vue
+++ b/apps/client-ui/pages/admin/identity-providers/[id].vue
@@ -9,6 +9,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { IdentityProvider } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { defineComponent, ref } from 'vue';
 import type { Ref } from 'vue';
 import {
@@ -24,6 +25,7 @@ import { LayoutKey, LayoutNavigationID } from '~/config/layout';
 import { updateObjectProperties } from '../../../utils';
 
 export default defineComponent({
+    components: { FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
@@ -78,7 +80,10 @@ export default defineComponent({
 <template>
     <div>
         <h1 class="title no-border mb-3">
-            <i class="fa-solid fa-atom me-1" /> {{ entity.name }}
+            <i class="fa-solid fa-atom me-1" /> <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">Details</span>
         </h1>
         <div class="mb-2">

--- a/apps/client-ui/pages/admin/identity-providers/index/index.vue
+++ b/apps/client-ui/pages/admin/identity-providers/index/index.vue
@@ -20,11 +20,13 @@ import {
     storeToRefs,
     usePermissionCheck,
 } from '@authup/client-web-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import type { BuildInput } from 'rapiq';
 import { defineNuxtComponent } from '#app';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         ATitle,
         APagination,
         ASearch,
@@ -122,6 +124,12 @@ export default defineNuxtComponent({
                 head-variant="'dark'"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(created_at)="data">
                     <VCTimeago :datetime="data.item.created_at" />
                 </template>

--- a/apps/client-ui/pages/admin/permissions/[id].vue
+++ b/apps/client-ui/pages/admin/permissions/[id].vue
@@ -9,6 +9,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { Permission } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 
 import { defineComponent, ref } from 'vue';
 import type { Ref } from 'vue';
@@ -19,6 +20,7 @@ import { useToast } from '../../../composables/toast';
 import { updateObjectProperties } from '../../../utils';
 
 export default defineComponent({
+    components: { FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
@@ -93,7 +95,10 @@ export default defineComponent({
     <div>
         <h1 class="title no-border mb-3">
             <i class="fa fa-user me-1" />
-            {{ entity.name }}
+            <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">
                 Details
             </span>

--- a/apps/client-ui/pages/admin/permissions/index/index.vue
+++ b/apps/client-ui/pages/admin/permissions/index/index.vue
@@ -21,11 +21,13 @@ import {
 import type { Permission } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
 
+import { FDisplayName } from '@privateaim/client-vue';
 import type { BuildInput } from 'rapiq';
 import { defineNuxtComponent } from '#app';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         ATitle,
         APagination,
         ASearch,
@@ -123,6 +125,12 @@ export default defineNuxtComponent({
                 head-variant="'dark'"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(built_in)="data">
                     <i
                         class="fas"

--- a/apps/client-ui/pages/admin/policies/[id].vue
+++ b/apps/client-ui/pages/admin/policies/[id].vue
@@ -2,6 +2,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { Policy } from '@authup/core-kit';
 import { PermissionName as AuthupPermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { defineComponent, ref } from 'vue';
 import type { Ref } from 'vue';
 import { useRoute } from 'vue-router';
@@ -11,6 +12,7 @@ import { LayoutKey, LayoutNavigationID } from '../../../config/layout';
 import { updateObjectProperties } from '../../../utils';
 
 export default defineComponent({
+    components: { FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
@@ -69,7 +71,10 @@ export default defineComponent({
     <div>
         <h1 class="title no-border mb-3">
             <i class="fa fa-balance-scale me-1" />
-            {{ entity.name }}
+            <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">
                 Details
             </span>

--- a/apps/client-ui/pages/admin/policies/index/index.vue
+++ b/apps/client-ui/pages/admin/policies/index/index.vue
@@ -15,10 +15,12 @@ import {
 } from '@authup/client-web-kit';
 import type { Policy } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import type { BuildInput } from 'rapiq';
 
 export default defineComponent({
     components: {
+        FDisplayName,
         ATitle,
         APagination,
         ASearch,
@@ -109,6 +111,12 @@ export default defineComponent({
                 :busy="props.busy"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(created_at)="data">
                     <VCTimeago :datetime="data.item.created_at" />
                 </template>

--- a/apps/client-ui/pages/admin/realms/[id].vue
+++ b/apps/client-ui/pages/admin/realms/[id].vue
@@ -9,6 +9,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { Realm } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 
 import { defineComponent, ref } from 'vue';
 import type { Ref } from 'vue';
@@ -25,6 +26,7 @@ import { LayoutKey, LayoutNavigationID } from '~/config/layout';
 import { updateObjectProperties } from '../../../utils';
 
 export default defineComponent({
+    components: { FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
@@ -79,7 +81,10 @@ export default defineComponent({
 <template>
     <div>
         <h1 class="title no-border mb-3">
-            <i class="fa-solid fa-building me-1" /> {{ entity.name }}
+            <i class="fa-solid fa-building me-1" /> <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">Details</span>
         </h1>
         <div class="mb-2">

--- a/apps/client-ui/pages/admin/realms/index/index.vue
+++ b/apps/client-ui/pages/admin/realms/index/index.vue
@@ -9,6 +9,7 @@
 import { VCTimeago } from '@vuecs/timeago';
 import { BTable } from 'bootstrap-vue-next';
 import { REALM_MASTER_NAME, type Realm } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { PermissionName } from '@authup/core-kit';
 import {
     AEntityDelete, 
@@ -25,6 +26,7 @@ import { defineNuxtComponent } from '#imports';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         ATitle,
         APagination,
         ASearch,
@@ -114,6 +116,12 @@ export default defineNuxtComponent({
                 head-variant="'dark'"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(created_at)="data">
                     <VCTimeago :datetime="data.item.created_at" />
                 </template>

--- a/apps/client-ui/pages/admin/roles/[id].vue
+++ b/apps/client-ui/pages/admin/roles/[id].vue
@@ -9,6 +9,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { Role } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { defineComponent, ref } from 'vue';
 import type { Ref } from 'vue';
 import {
@@ -24,6 +25,7 @@ import { LayoutKey, LayoutNavigationID } from '~/config/layout';
 import { updateObjectProperties } from '../../../utils';
 
 export default defineComponent({
+    components: { FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
@@ -90,7 +92,10 @@ export default defineComponent({
 <template>
     <div>
         <h1 class="title no-border mb-3">
-            <i class="fa-solid fa-theater-masks me-1" /> {{ entity.name }}
+            <i class="fa-solid fa-theater-masks me-1" /> <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">Details</span>
         </h1>
         <div class="mb-2">

--- a/apps/client-ui/pages/admin/roles/index/index.vue
+++ b/apps/client-ui/pages/admin/roles/index/index.vue
@@ -19,11 +19,13 @@ import {
     storeToRefs,
     usePermissionCheck,
 } from '@authup/client-web-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import type { BuildInput } from 'rapiq';
 import { defineNuxtComponent } from '#imports';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         ATitle,
         APagination,
         ASearch,
@@ -119,6 +121,12 @@ export default defineNuxtComponent({
                 :busy="props.busy"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(built_in)="data">
                     <i
                         class="fas"

--- a/apps/client-ui/pages/admin/users/[id].vue
+++ b/apps/client-ui/pages/admin/users/[id].vue
@@ -9,6 +9,7 @@
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { User } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { defineComponent, ref } from 'vue';
 import type { Ref } from 'vue';
 import {
@@ -25,7 +26,7 @@ import { LayoutKey, LayoutNavigationID } from '~/config/layout';
 import DomainEntityNav from '../../../components/DomainEntityNav';
 
 export default defineComponent({
-    components: { DomainEntityNav },
+    components: { DomainEntityNav, FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
@@ -93,7 +94,10 @@ export default defineComponent({
     <div>
         <h1 class="title no-border mb-3">
             <i class="fa fa-user me-1" />
-            {{ entity.name }}
+            <FDisplayName
+                :name="entity.name"
+                :display-name="entity.display_name"
+            />
             <span class="sub-title ms-1">
                 Details
             </span>

--- a/apps/client-ui/pages/admin/users/index/index.vue
+++ b/apps/client-ui/pages/admin/users/index/index.vue
@@ -19,11 +19,17 @@ import {
     usePermissionCheck,
 } from '@authup/client-web-kit';
 import type { BuildInput } from 'rapiq';
-import { FPagination, FSearch, FTitle } from '@privateaim/client-vue';
+import {
+    FDisplayName, 
+    FPagination, 
+    FSearch, 
+    FTitle,
+} from '@privateaim/client-vue';
 import { defineNuxtComponent } from '#app';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         FPagination, 
         FSearch, 
         FTitle, 
@@ -107,6 +113,12 @@ export default defineNuxtComponent({
                 head-variant="'dark'"
                 outlined
             >
+                <template #cell(name)="data">
+                    <FDisplayName
+                        :name="data.item.name"
+                        :display-name="data.item.display_name"
+                    />
+                </template>
                 <template #cell(created_at)="data">
                     <VCTimeago :datetime="data.item.created_at" />
                 </template>

--- a/apps/client-ui/pages/analyses/[id]/image.vue
+++ b/apps/client-ui/pages/analyses/[id]/image.vue
@@ -13,6 +13,7 @@ import {
     FAnalysisImageCommandArguments,
     FAnalysisMasterImagePicker,
     FAnalysisTypeBucket,
+    FPagination,
 } from '@privateaim/client-vue';
 import type { Analysis, AnalysisBucketFile } from '@privateaim/core-kit';
 import type { PropType } from 'vue';
@@ -27,6 +28,7 @@ export default defineComponent({
         FAnalysisTypeBucket,
         FAnalysisImageCommand,
         FAnalysisImageCommandArguments,
+        FPagination,
     },
     props: { entity: { type: Object as PropType<Analysis> } },
     emits: ['updated'],
@@ -186,6 +188,12 @@ export default defineComponent({
                                                 </div>
                                             </template>
                                         </FAnalysisBucketFile>
+                                    </template>
+                                    <template #footer="footerProps">
+                                        <FPagination
+                                            :load="footerProps.load"
+                                            :meta="footerProps.meta"
+                                        />
                                     </template>
                                 </FAnalysisBucketFiles>
                             </template>

--- a/apps/client-ui/pages/login.vue
+++ b/apps/client-ui/pages/login.vue
@@ -7,9 +7,10 @@
 <script lang="ts">
 import { AIdentityProviders, injectHTTPClient } from '@authup/client-web-kit';
 import {
-    FPagination, 
-    FSearch, 
-    FTitle, 
+    FDisplayName,
+    FPagination,
+    FSearch,
+    FTitle,
     LoginForm,
 } from '@privateaim/client-vue';
 import {
@@ -26,6 +27,7 @@ import { LayoutKey, LayoutNavigationID } from '../config/layout';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         LoginForm,
         ListPagination: FPagination,
         ListSearch: FSearch,
@@ -108,14 +110,22 @@ export default defineNuxtComponent({
                     </template>
                     <template #item="props">
                         <div>
-                            <strong>{{ props.data.name }}</strong>
+                            <strong>
+                                <FDisplayName
+                                    :name="props.data.name"
+                                    :display-name="props.data.display_name"
+                                />
+                            </strong>
                         </div>
                         <div class="ms-auto">
                             <a
                                 :href="buildIdentityProviderURL(props.data.id)"
                                 class="btn btn-primary btn-xs"
                             >
-                                {{ props.data.name }}
+                                <FDisplayName
+                                    :name="props.data.name"
+                                    :display-name="props.data.display_name"
+                                />
                             </a>
                         </div>
                     </template>

--- a/apps/client-ui/pages/projects/[id]/index.vue
+++ b/apps/client-ui/pages/projects/[id]/index.vue
@@ -7,9 +7,10 @@
 <script lang="ts">
 import { ARealm } from '@authup/client-web-kit';
 import {
-    FMasterImage, 
-    FProjectCreator, 
-    FProjectNodeApprovalStatus, 
+    FDisplayName,
+    FMasterImage,
+    FProjectCreator,
+    FProjectNodeApprovalStatus,
     FProjectNodes,
 } from '@privateaim/client-vue';
 import type { Project, ProjectNode } from '@privateaim/core-kit';
@@ -20,6 +21,7 @@ import { LayoutKey, LayoutNavigationID } from '../../../config/layout';
 
 export default defineNuxtComponent({
     components: {
+        FDisplayName,
         FProjectCreator,
         ARealm,
         FMasterImage,
@@ -104,7 +106,10 @@ export default defineNuxtComponent({
                         <div class="h6">
                             <ARealm :entity-id="entity.realm_id">
                                 <template #default="{ data }">
-                                    {{ data.name }}
+                                    <FDisplayName
+                                        :name="data.name"
+                                        :display-name="data.display_name"
+                                    />
                                 </template>
                                 <template #error>
                                     {{ entity.realm_id }}

--- a/apps/client-ui/pages/users/[id].vue
+++ b/apps/client-ui/pages/users/[id].vue
@@ -7,6 +7,7 @@
 <script lang="ts">
 import { injectHTTPClient } from '@authup/client-web-kit';
 import type { User } from '@authup/core-kit';
+import { FDisplayName } from '@privateaim/client-vue';
 import { isClientErrorWithStatusCode } from 'hapic';
 import type { Ref } from 'vue';
 import { ref } from 'vue';
@@ -21,7 +22,7 @@ import DomainEntityNav from '../../components/DomainEntityNav';
 import { LayoutKey, LayoutNavigationID } from '../../config/layout';
 
 export default defineNuxtComponent({
-    components: { DomainEntityNav },
+    components: { DomainEntityNav, FDisplayName },
     async setup() {
         definePageMeta({
             [LayoutKey.REQUIRED_LOGGED_IN]: true,
@@ -60,7 +61,10 @@ export default defineNuxtComponent({
     <div class="">
         <div class="m-b-10">
             <h4 class="title">
-                {{ user.name }}
+                <FDisplayName
+                    :name="user.name"
+                    :display-name="user.display_name"
+                />
                 <span class="sub-title">Profil</span>
             </h4>
         </div>

--- a/packages/client-vue/src/components/analysis-node/FAnalysisNode.ts
+++ b/packages/client-vue/src/components/analysis-node/FAnalysisNode.ts
@@ -20,10 +20,11 @@ import {
 } from 'vue';
 import type { PropType, VNodeChild } from 'vue';
 import {
-    createEntityManager, 
-    defineEntityManagerEvents, 
+    createEntityManager,
+    defineEntityManagerEvents,
     injectCoreHTTPClient,
 } from '../../core';
+import FDisplayName from '../FDisplayName';
 
 enum Direction {
     IN = 'in',
@@ -120,8 +121,10 @@ export default defineComponent({
                 ) {
                     if (props.target === Target.ANALYSIS) {
                         return h('div', [
-                            manager.data.value?.analysis.display_name ||
-                            manager.data.value?.analysis.name,
+                            h(FDisplayName, {
+                                name: manager.data.value?.analysis.name,
+                                displayName: manager.data.value?.analysis.display_name,
+                            }),
                         ]);
                     }
                     if (props.target === Target.NODE) {

--- a/packages/client-vue/src/components/analysis-node/FAnalysisNodes.ts
+++ b/packages/client-vue/src/components/analysis-node/FAnalysisNodes.ts
@@ -24,6 +24,7 @@ import {
     defineListEvents, 
     defineListProps,
 } from '../../core';
+import FDisplayName from '../FDisplayName';
 import type { DomainDetailsSlotProps } from '../type';
 import FAnalysisNode from './FAnalysisNode';
 
@@ -216,8 +217,10 @@ export default defineComponent({
                                 slotProps.data.analysis
                             ) {
                                 text = h('div', [
-                                    slotProps.data.analysis.display_name ||
-                                    slotProps.data.analysis.name,
+                                    h(FDisplayName, {
+                                        name: slotProps.data.analysis.name,
+                                        displayName: slotProps.data.analysis.display_name,
+                                    }),
                                 ]);
                             } else {
                                 text = h('div', [slotProps.data.id]);

--- a/packages/client-vue/src/components/project-node/FProjectNode.ts
+++ b/packages/client-vue/src/components/project-node/FProjectNode.ts
@@ -23,6 +23,7 @@ import type {
     VNodeChild,
 } from 'vue';
 import { createEntityManager, defineEntityManagerEvents, injectCoreHTTPClient } from '../../core';
+import FDisplayName from '../FDisplayName';
 
 enum Direction {
     IN = 'in',
@@ -119,8 +120,10 @@ export default defineComponent({
                 ) {
                     if (props.target === Target.PROJECT) {
                         return h('div', [
-                            manager.data.value?.project.display_name ||
-                            manager.data.value?.project.name,
+                            h(FDisplayName, {
+                                name: manager.data.value?.project.name,
+                                displayName: manager.data.value?.project.display_name,
+                            }),
                         ]);
                     }
                     if (props.target === Target.NODE) {

--- a/packages/client-vue/src/components/project-node/FProjectNodes.ts
+++ b/packages/client-vue/src/components/project-node/FProjectNodes.ts
@@ -26,6 +26,7 @@ import {
     defineListEvents, 
     defineListProps,
 } from '../../core';
+import FDisplayName from '../FDisplayName';
 import type { DomainDetailsSlotProps } from '../type';
 import FProjectNode from './FProjectNode';
 
@@ -59,8 +60,8 @@ export default defineComponent({
             default: false,
         },
     },
-    slots: Object as SlotsType<ListSlotsType<ProjectNode>>,
     emits: defineListEvents<ProjectNode>(),
+    slots: Object as SlotsType<ListSlotsType<ProjectNode>>,
     async setup(props, ctx) {
         const source = computed(() => (props.target === DomainType.NODE ?
             DomainType.PROJECT :
@@ -234,8 +235,10 @@ export default defineComponent({
                                 slotProps.data.project
                             ) {
                                 text = h('div', [
-                                    slotProps.data.project.display_name ||
-                                    slotProps.data.project.name,
+                                    h(FDisplayName, {
+                                        name: slotProps.data.project.name,
+                                        displayName: slotProps.data.project.display_name,
+                                    }),
                                 ]);
                             } else {
                                 text = h('div', [slotProps.data.id]);

--- a/packages/client-vue/src/components/project/FProjectCreator.vue
+++ b/packages/client-vue/src/components/project/FProjectCreator.vue
@@ -9,11 +9,13 @@ import { ARobot, AUser } from '@authup/client-web-kit';
 import type { Project } from '@privateaim/core-kit';
 import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
+import FDisplayName from '../FDisplayName';
 
 export default defineComponent({
     components: {
         AUser,
         ARobot,
+        FDisplayName,
     },
     props: {
         entity: {
@@ -32,7 +34,10 @@ export default defineComponent({
                         name="default"
                         :data="data"
                     >
-                        {{ data.name }}
+                        <FDisplayName
+                            :name="data.name"
+                            :display-name="data.display_name"
+                        />
                     </slot>
                 </template>
                 <template #error="error">
@@ -52,7 +57,10 @@ export default defineComponent({
                         name="default"
                         :data="data"
                     >
-                        {{ data.name }}
+                        <FDisplayName
+                            :name="data.name"
+                            :display-name="data.display_name"
+                        />
                     </slot>
                 </template>
                 <template #error="error">

--- a/packages/client-vue/src/components/project/FProjects.ts
+++ b/packages/client-vue/src/components/project/FProjects.ts
@@ -11,9 +11,10 @@ import {
     DomainType,
 } from '@privateaim/core-kit';
 import type { SlotsType } from 'vue';
-import { defineComponent } from 'vue';
+import { defineComponent, h } from 'vue';
 import type { ListSlotsType } from '../../core';
 import { createList, defineListEvents, defineListProps } from '../../core';
+import FDisplayName from '../FDisplayName';
 
 const FProjects = defineComponent({
     props: {
@@ -23,8 +24,8 @@ const FProjects = defineComponent({
             default: undefined,
         },
     },
-    slots: Object as SlotsType<ListSlotsType<Project>>,
     emits: defineListEvents<Project>(),
+    slots: Object as SlotsType<ListSlotsType<Project>>,
     setup(props, setup) {
         const { render, setDefaults } = createList({
             type: `${DomainType.PROJECT}`,
@@ -32,7 +33,26 @@ const FProjects = defineComponent({
             setup,
         });
 
-        setDefaults({ noMore: { content: 'No more projects available...' } });
+        setDefaults({
+            item: {
+                content(item, itemProps, slotContent) {
+                    if (slotContent.slot) {
+                        return slotContent.slot;
+                    }
+
+                    return [
+                        slotContent.icon,
+                        h(FDisplayName, {
+                            name: item.name,
+                            displayName: item.display_name,
+                        }),
+                        slotContent.actions,
+                    ];
+                },
+            },
+
+            noMore: { content: 'No more projects available...' },
+        });
 
         return () => render();
     },


### PR DESCRIPTION
## Summary

Fixes two UI issues:

**1. Entrypoint selection pagination (analysis → Image tab)**
The entrypoint file list only showed the first 10 code files with no way to page further. An `FPagination` footer is now rendered, so all uploaded files are selectable as entrypoint.

**2. `display_name` in views**
The project picker in the analysis form only showed `project.name`, ignoring `display_name`. Beyond fixing the picker (via a default item renderer on `FProjects`), all views (not form inputs) that render an entity carrying both `name` and `display_name` now resolve the label through `FDisplayName`:

- `client-vue`: `FProjects` default item, `FProjectNode(s)`/`FAnalysisNode(s)` (replacing inline `display_name || name`), `FProjectCreator` (user/robot)
- `client-ui`: layout header user link, login identity-provider list, user profile page, project realm card, admin detail page headers and admin index table name cells (users, roles, realms, clients, permissions, policies, identity-providers), client scope labels

Untouched on purpose: entities without `display_name` (`Node`, `Registry`, `MasterImage`, bucket files, events) and form inputs.

## Verification

- `eslint` clean on all changed files
- `nx run @privateaim/client-vue:build` (tsdown + vue-tsc) passes
- `client-ui` Nuxt build fails identically on clean `master` in this environment (stale node_modules, `@vuecs/pagination` CSS specifier) — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized name display across admin interfaces and user-facing pages for consistent formatting.
  * Added pagination controls to the analysis image page for improved navigation of file listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->