### PR TITLE
fix(ui): adapt selected bucket-file row highlight for dark mode

### DIFF
--- a/packages/client-vue/src/components/bucket-file/FBucketFile.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFile.vue
@@ -192,8 +192,11 @@ export default defineComponent({
     align-items: center;
 }
 
+/* Selected-row highlight as a brand-tinted step above the content surface,
+   so it flips with light/dark instead of the old fixed light-blue (#c5d7e7,
+   unreadable on the dark content bg). */
 .bucket-file.checked {
-    background: #c5d7e7;
+    background: color-mix(in oklab, var(--vc-color-primary-600) 16%, var(--vc-color-bg));
 }
 
 .form-check-input {


### PR DESCRIPTION
The .bucket-file.checked background was a fixed light-blue (#c5d7e7) that washed out and clashed against the dark content surface. Derive it from the brand primary token mixed over --vc-color-bg so it flips with light/dark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced selected item styling in bucket files to properly adapt to light and dark mode themes for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->