### PR TITLE
feat(client-vue): redesign bucket file upload with drag-and-drop dropzone

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import config from '@tada5hi/eslint-config';
+import globals from 'globals';
 
 export default [
     ...await config(),
@@ -14,7 +15,11 @@ export default [
         ],
     },
     {
+        // SFCs are browser/SSR code — the shared config only registers Node
+        // globals for `.vue` files, so DOM-only globals (DragEvent, FileList,
+        // HTMLInputElement, …) otherwise trip `no-undef`.
         files: ['**/*.vue'],
+        languageOptions: { globals: { ...globals.browser } },
         rules: { '@typescript-eslint/no-explicit-any': 'off' },
     },
 ];

--- a/packages/client-vue/src/components/bucket-file/FBucketFile.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFile.vue
@@ -143,7 +143,7 @@ export default defineComponent({
         >
             <span>
                 <template v-if="data">
-                    {{ data.name }}
+                    {{ data.path || data.name }}
                 </template>
                 <template v-else>
                     ...

--- a/packages/client-vue/src/components/bucket-file/FBucketFileForm.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFileForm.vue
@@ -15,6 +15,14 @@ export default defineComponent({
             type: Object as PropType<File>,
             required: true,
         },
+        // Explicit relative path (incl. directories). Drag-dropped files have
+        // an empty webkitRelativePath, so the parent supplies the path it
+        // derived from the FileSystem entry; falls back to webkitRelativePath
+        // (directory picker) then the bare name.
+        relativePath: {
+            type: String,
+            default: '',
+        },
         pathSelected: {
             type: Boolean,
             default: false,
@@ -22,13 +30,9 @@ export default defineComponent({
     },
     emits: ['drop'],
     setup(props, { emit }) {
-        const path = computed(() => {
-            let filename = props.file.name;
-            if (props.file.webkitRelativePath) {
-                filename = props.file.webkitRelativePath;
-            }
-            return filename;
-        });
+        const path = computed(() => props.relativePath ||
+            props.file.webkitRelativePath ||
+            props.file.name);
 
         const drop = () => {
             emit('drop', props.file);

--- a/packages/client-vue/src/components/bucket-file/FBucketFilesUpload.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFilesUpload.vue
@@ -146,11 +146,17 @@ export default defineComponent({
             }
 
             if (entries.length > 0) {
-                const collected: StagedFile[] = [];
-                for (const entry of entries) {
-                    await collectEntry(entry, collected);
+                try {
+                    const collected: StagedFile[] = [];
+                    for (const entry of entries) {
+                        await collectEntry(entry, collected);
+                    }
+                    addStaged(collected);
+                } catch (e) {
+                    // Entry-API traversal can reject (read errors, permissions)
+                    // — surface it instead of failing the drop silently.
+                    emit('failed', e);
                 }
-                addStaged(collected);
                 return;
             }
 

--- a/packages/client-vue/src/components/bucket-file/FBucketFilesUpload.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFilesUpload.vue
@@ -5,10 +5,59 @@
   -  view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
-import { hasOwnProperty, humanFileSize } from '@privateaim/kit';
+import { humanFileSize } from '@privateaim/kit';
 import { computed, defineComponent, ref } from 'vue';
 import { injectStorageHTTPClient, wrapFnWithBusyState } from '../../core';
 import FBucketFileForm from './FBucketFileForm.vue';
+
+// A staged file plus the relative path (incl. directories) to upload it under.
+// The path is sent as the multipart filename; the storage service runs busboy
+// with `preservePath: true` and keeps it as the bucket-file `path`/`directory`.
+type StagedFile = { file: File; path: string };
+
+// Drag-dropped File objects carry an empty `webkitRelativePath`, so dropped
+// directories must be expanded via the FileSystem Entry API and the path read
+// from `entry.fullPath` instead. (The directory picker, by contrast, fills
+// `webkitRelativePath` itself.)
+function readEntryFile(entry: FileSystemFileEntry): Promise<File> {
+    return new Promise((resolve, reject) => {
+        entry.file(resolve, reject);
+    });
+}
+
+function readAllEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+    return new Promise((resolve, reject) => {
+        const entries: FileSystemEntry[] = [];
+        // readEntries yields at most ~100 entries per call; keep reading until
+        // it returns an empty batch.
+        const readBatch = () => {
+            reader.readEntries((batch) => {
+                if (batch.length === 0) {
+                    resolve(entries);
+                    return;
+                }
+                entries.push(...batch);
+                readBatch();
+            }, reject);
+        };
+        readBatch();
+    });
+}
+
+async function collectEntry(entry: FileSystemEntry, out: StagedFile[]): Promise<void> {
+    if (entry.isFile) {
+        const file = await readEntryFile(entry as FileSystemFileEntry);
+        out.push({ file, path: entry.fullPath.replace(/^\/+/, '') });
+        return;
+    }
+
+    if (entry.isDirectory) {
+        const children = await readAllEntries((entry as FileSystemDirectoryEntry).createReader());
+        for (const child of children) {
+            await collectEntry(child, out);
+        }
+    }
+}
 
 export default defineComponent({
     components: { FBucketFileForm },
@@ -23,27 +72,43 @@ export default defineComponent({
         const storageClient = injectStorageHTTPClient();
 
         const busy = ref(false);
-        const tempFiles = ref<File[]>([]);
+        const tempFiles = ref<StagedFile[]>([]);
         const directoryMode = ref<boolean>(true);
         const dragOver = ref<boolean>(false);
 
         const totalSize = computed(
-            () => tempFiles.value.reduce((acc, file) => acc + file.size, 0),
+            () => tempFiles.value.reduce((acc, item) => acc + item.file.size, 0),
         );
 
-        const addFiles = (files: FileList | null) => {
+        // Stage files, deduping by relative path. The server enforces a unique
+        // (bucket_id, path), so re-adding the same path would only produce a
+        // duplicate row and a 409 on upload — drop it here instead.
+        const addStaged = (staged: StagedFile[]) => {
+            const existing = new Set(tempFiles.value.map((item) => item.path));
+            for (const item of staged) {
+                if (!existing.has(item.path)) {
+                    tempFiles.value.push(item);
+                    existing.add(item.path);
+                }
+            }
+        };
+
+        const addFileList = (files: FileList | null) => {
             if (!files) {
                 return;
             }
 
-            for (const file of files) {
-                tempFiles.value.push(file);
-            }
+            addStaged(
+                Array.from(files).map((file) => ({
+                    file,
+                    path: file.webkitRelativePath || file.name,
+                })),
+            );
         };
 
         const checkTempFiles = (event: Event) => {
             const target = event.target as HTMLInputElement;
-            addFiles(target.files);
+            addFileList(target.files);
             target.value = '';
         };
 
@@ -57,27 +122,44 @@ export default defineComponent({
             dragOver.value = false;
         };
 
-        const onDrop = (event: DragEvent) => {
+        const onDrop = async (event: DragEvent) => {
             dragOver.value = false;
 
             if (busy.value) {
                 return;
             }
 
-            addFiles(event.dataTransfer ? event.dataTransfer.files : null);
+            // `webkitGetAsEntry()` must be called synchronously while the
+            // DataTransferItemList is still alive — collect entries before any
+            // await, then traverse them asynchronously.
+            const items = event.dataTransfer?.items;
+            const entries: FileSystemEntry[] = [];
+            if (items) {
+                for (const item of Array.from(items)) {
+                    const entry = typeof item.webkitGetAsEntry === 'function' ?
+                        item.webkitGetAsEntry() :
+                        null;
+                    if (entry) {
+                        entries.push(entry);
+                    }
+                }
+            }
+
+            if (entries.length > 0) {
+                const collected: StagedFile[] = [];
+                for (const entry of entries) {
+                    await collectEntry(entry, collected);
+                }
+                addStaged(collected);
+                return;
+            }
+
+            // Fallback for browsers without the entry API: flat files only.
+            addFileList(event.dataTransfer?.files ?? null);
         };
 
         const dropTempFile = (file: File) => {
-            const index = tempFiles.value.findIndex((el) => {
-                if (
-                    hasOwnProperty(el, 'webkitRelativePath') &&
-                    hasOwnProperty(file, 'webkitRelativePath')
-                ) {
-                    return el.webkitRelativePath === file.webkitRelativePath;
-                }
-                return el.name === file.name;
-            });
-
+            const index = tempFiles.value.findIndex((el) => el.file === file);
             if (index !== -1) {
                 tempFiles.value.splice(index, 1);
             }
@@ -93,7 +175,10 @@ export default defineComponent({
             try {
                 const formData = new FormData();
                 for (let i = 0; i < tempFiles.value.length; i++) {
-                    formData.append(`files[${i}]`, tempFiles.value[i]);
+                    const { file, path } = tempFiles.value[i];
+                    // 3rd arg sets the multipart filename — send the relative
+                    // path so the directory structure survives to the server.
+                    formData.append(`files[${i}]`, file, path);
                 }
 
                 const { data: bucketFiles } = await storageClient.bucket.upload(
@@ -212,10 +297,11 @@ export default defineComponent({
 
             <div class="upload-file-list flex flex-col">
                 <FBucketFileForm
-                    v-for="(file, key) in tempFiles"
+                    v-for="(item, key) in tempFiles"
                     :key="key"
                     class="me-1"
-                    :file="file"
+                    :file="item.file"
+                    :relative-path="item.path"
                     @drop="dropTempFile"
                 />
             </div>
@@ -349,8 +435,29 @@ export default defineComponent({
     pointer-events: none;
 }
 
+/* Visually hidden but kept in the tab order (NOT `display: none`, which drops
+   it from focus) so keyboard users can tab to the input and open the picker
+   with Enter/Space. It is not overlaid on the dropzone — that would let the
+   native file input swallow drops and fight the label's @drop handler. */
 .upload-dropzone__input {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Surface keyboard focus on the wrapping label, since the input itself is
+   visually hidden. */
+.upload-dropzone:focus-within {
+    border-style: solid;
+    border-color: var(--vc-color-primary-600);
+    color: var(--vc-color-fg);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--vc-color-primary-600) 30%, transparent);
 }
 
 .upload-dropzone__icon {

--- a/packages/client-vue/src/components/bucket-file/FBucketFilesUpload.vue
+++ b/packages/client-vue/src/components/bucket-file/FBucketFilesUpload.vue
@@ -5,8 +5,8 @@
   -  view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
-import { hasOwnProperty } from '@privateaim/kit';
-import { defineComponent, ref } from 'vue';
+import { hasOwnProperty, humanFileSize } from '@privateaim/kit';
+import { computed, defineComponent, ref } from 'vue';
 import { injectStorageHTTPClient, wrapFnWithBusyState } from '../../core';
 import FBucketFileForm from './FBucketFileForm.vue';
 
@@ -25,36 +25,66 @@ export default defineComponent({
         const busy = ref(false);
         const tempFiles = ref<File[]>([]);
         const directoryMode = ref<boolean>(true);
-        const vNode = ref<null | string>(null);
+        const dragOver = ref<boolean>(false);
 
-        const checkTempFiles = ($event: any) => {
-            $event.preventDefault();
+        const totalSize = computed(
+            () => tempFiles.value.reduce((acc, file) => acc + file.size, 0),
+        );
 
-            for (let i = 0; i < $event.target.files.length; i++) {
-                tempFiles.value.push($event.target.files[i]);
+        const addFiles = (files: FileList | null) => {
+            if (!files) {
+                return;
             }
 
-            if (vNode.value) {
-                vNode.value = '';
+            for (const file of files) {
+                tempFiles.value.push(file);
             }
-
-            $event.target.value = '';
         };
 
-        const dropTempFile = ($event: any) => {
-            const index = tempFiles.value.findIndex((file) => {
+        const checkTempFiles = (event: Event) => {
+            const target = event.target as HTMLInputElement;
+            addFiles(target.files);
+            target.value = '';
+        };
+
+        const onDragOver = () => {
+            if (!busy.value) {
+                dragOver.value = true;
+            }
+        };
+
+        const onDragLeave = () => {
+            dragOver.value = false;
+        };
+
+        const onDrop = (event: DragEvent) => {
+            dragOver.value = false;
+
+            if (busy.value) {
+                return;
+            }
+
+            addFiles(event.dataTransfer ? event.dataTransfer.files : null);
+        };
+
+        const dropTempFile = (file: File) => {
+            const index = tempFiles.value.findIndex((el) => {
                 if (
-                    hasOwnProperty(file, 'webkitRelativePath') &&
-                    hasOwnProperty($event, 'webkitRelativePath')
+                    hasOwnProperty(el, 'webkitRelativePath') &&
+                    hasOwnProperty(file, 'webkitRelativePath')
                 ) {
-                    return file.webkitRelativePath === $event.webkitRelativePath;
+                    return el.webkitRelativePath === file.webkitRelativePath;
                 }
-                return file.name === $event.name;
+                return el.name === file.name;
             });
 
             if (index !== -1) {
                 tempFiles.value.splice(index, 1);
             }
+        };
+
+        const clearFiles = () => {
+            tempFiles.value = [];
         };
 
         const upload = wrapFnWithBusyState(busy, async () => {
@@ -82,77 +112,354 @@ export default defineComponent({
         return {
             directoryMode,
             busy,
-            vNode,
+            dragOver,
             tempFiles,
+            totalSize,
             checkTempFiles,
+            onDragOver,
+            onDragLeave,
+            onDrop,
             dropTempFile,
+            clearFiles,
             upload,
+            humanFileSize,
         };
     },
 });
 </script>
 <template>
-    <div class="flex flex-col">
-        <div>
-            <div class="form-group">
-                <label class="form-label">{{ directoryMode ? 'Directories' : 'Files' }}</label>
-                <input
-                    id="files"
-                    ref="vNode"
-                    type="file"
-                    :webkitdirectory="directoryMode"
-                    class="form-control"
-                    multiple
-                    :disbaled="busy"
-                    @change="checkTempFiles"
-                >
-            </div>
-            <div class="form-group mb-0">
-                <div class="form-check form-switch">
-                    <input
-                        id="train-file-manager-switch"
-                        v-model="directoryMode"
-                        class="form-check-input"
-                        type="checkbox"
-                    >
-                    <label
-                        class="form-check-label"
-                        for="train-file-manager-switch"
-                    >Directory Mode</label>
-                </div>
-            </div>
-        </div>
-        <div>
-            <div
-                v-if="tempFiles.length === 0"
-                class="alert alert-info alert-sm m-t-10"
+    <div class="flex flex-col gap-3">
+        <!-- Mode toggle -->
+        <div class="upload-mode">
+            <button
+                type="button"
+                class="upload-mode__btn"
+                :class="{ active: !directoryMode }"
+                :disabled="busy"
+                @click.prevent="directoryMode = false"
             >
-                You have not selected any {{ directoryMode ? 'directories' : 'files' }} to upload.
-            </div>
+                <VCIcon name="fa6-solid:file-lines" /> Files
+            </button>
+            <button
+                type="button"
+                class="upload-mode__btn"
+                :class="{ active: directoryMode }"
+                :disabled="busy"
+                @click.prevent="directoryMode = true"
+            >
+                <VCIcon name="fa6-solid:folder-open" /> Directories
+            </button>
+        </div>
 
-            <div class="flex flex-col">
-                <template
-                    v-for="(file,key) in tempFiles"
-                    :key="key"
-                >
-                    <FBucketFileForm
-                        class="me-1"
-                        :file="file"
-                        @drop="dropTempFile"
-                    />
+        <!-- Dropzone -->
+        <label
+            class="upload-dropzone"
+            :class="{ 'is-dragover': dragOver, 'is-busy': busy }"
+            @dragenter.prevent="onDragOver"
+            @dragover.prevent="onDragOver"
+            @dragleave.prevent="onDragLeave"
+            @drop.prevent="onDrop"
+        >
+            <input
+                id="files"
+                class="upload-dropzone__input"
+                type="file"
+                :webkitdirectory="directoryMode"
+                multiple
+                :disabled="busy"
+                @change="checkTempFiles"
+            >
+            <span class="upload-dropzone__icon">
+                <VCIcon name="fa6-solid:cloud-arrow-up" />
+            </span>
+            <span class="upload-dropzone__title">
+                <template v-if="dragOver">
+                    Release to add {{ directoryMode ? 'directories' : 'files' }}
                 </template>
-            </div>
+                <template v-else>
+                    Drag &amp; drop {{ directoryMode ? 'directories' : 'files' }} here, or
+                    <span class="upload-dropzone__browse">browse</span>
+                </template>
+            </span>
+            <span class="upload-dropzone__hint">
+                You can select multiple {{ directoryMode ? 'directories' : 'files' }} at once
+            </span>
+        </label>
 
-            <div class="form-group">
+        <!-- Selection -->
+        <template v-if="tempFiles.length === 0">
+            <div class="alert alert-info alert-sm mb-0">
+                <VCIcon name="fa6-solid:circle-info" />
+                No {{ directoryMode ? 'directories' : 'files' }} selected yet.
+            </div>
+        </template>
+        <template v-else>
+            <div class="upload-summary">
+                <span class="upload-summary__count">
+                    <strong>{{ tempFiles.length }}</strong>
+                    {{ tempFiles.length === 1 ? 'file' : 'files' }} ready
+                </span>
+                <span class="upload-summary__size">{{ humanFileSize(totalSize) }}</span>
                 <button
                     type="button"
-                    class="btn btn-sm btn-primary btn-block"
-                    :disabled="busy || tempFiles.length === 0"
-                    @click.prevent="upload"
+                    class="upload-summary__clear"
+                    :disabled="busy"
+                    @click.prevent="clearFiles"
                 >
-                    <VCIcon name="fa6-solid:upload" /> Upload
+                    <VCIcon name="fa6-solid:xmark" /> Clear all
                 </button>
             </div>
-        </div>
+
+            <div class="upload-file-list flex flex-col">
+                <FBucketFileForm
+                    v-for="(file, key) in tempFiles"
+                    :key="key"
+                    class="me-1"
+                    :file="file"
+                    @drop="dropTempFile"
+                />
+            </div>
+        </template>
+
+        <!-- Upload action -->
+        <button
+            type="button"
+            class="btn btn-sm btn-primary btn-block"
+            :disabled="busy || tempFiles.length === 0"
+            @click.prevent="upload"
+        >
+            <VCIcon name="fa6-solid:upload" />
+            Upload{{ tempFiles.length ? ` (${tempFiles.length})` : '' }}
+        </button>
     </div>
 </template>
+<style scoped>
+/* ============================================================
+   Segmented mode toggle (Files / Directories)
+   ============================================================ */
+.upload-mode {
+    display: inline-flex;
+    align-self: flex-start;
+    gap: 0.2rem;
+    padding: 0.2rem;
+    border-radius: 0.55rem;
+    background: var(--vc-color-bg-muted);
+    border: 1px solid var(--vc-color-border);
+}
+
+.upload-mode__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.8rem;
+    border: 0;
+    border-radius: 0.4rem;
+    background: transparent;
+    color: var(--vc-color-fg-muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upload-mode__btn:hover:not(:disabled):not(.active) {
+    color: var(--vc-color-fg);
+}
+
+.upload-mode__btn.active {
+    color: var(--vc-color-on-primary, #fff);
+    background: var(--vc-color-primary-600);
+    box-shadow: 0 2px 8px -2px color-mix(in oklab, var(--vc-color-primary-600) 60%, transparent);
+}
+
+/* Active button keeps its white label on hover — only the surface darkens. */
+.upload-mode__btn.active:hover:not(:disabled) {
+    background: var(--vc-color-primary-700);
+}
+
+.upload-mode__btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+/* ============================================================
+   Dropzone
+   ============================================================ */
+.upload-dropzone {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    padding: 2.25rem 1.25rem;
+    text-align: center;
+    cursor: pointer;
+    overflow: hidden;
+    border-radius: 0.7rem;
+    border: 1.5px dashed var(--vc-color-border);
+    background-color: var(--vc-color-bg-muted);
+    color: var(--vc-color-fg-muted);
+    transition:
+        border-color 0.2s ease,
+        background-color 0.2s ease,
+        color 0.2s ease,
+        box-shadow 0.25s ease,
+        transform 0.25s ease;
+}
+
+/* Soft brand wash that fades in on hover / drag. */
+.upload-dropzone::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0;
+    background: radial-gradient(
+        120% 120% at 50% -10%,
+        color-mix(in oklab, var(--privateaim-brand-purple) 12%, transparent),
+        transparent 60%
+    );
+    transition: opacity 0.25s ease;
+}
+
+.upload-dropzone:hover {
+    border-color: color-mix(in oklab, var(--vc-color-primary-600) 55%, var(--vc-color-border));
+    color: var(--vc-color-fg);
+}
+
+.upload-dropzone:hover::before {
+    opacity: 1;
+}
+
+.upload-dropzone.is-dragover {
+    border-style: solid;
+    border-color: var(--vc-color-primary-600);
+    color: var(--vc-color-fg);
+    transform: translateY(-2px);
+    box-shadow: 0 14px 40px -16px color-mix(in oklab, var(--vc-color-primary-600) 70%, transparent);
+}
+
+.upload-dropzone.is-dragover::before {
+    opacity: 1;
+}
+
+.upload-dropzone.is-busy {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.upload-dropzone__input {
+    display: none;
+}
+
+.upload-dropzone__icon {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: 3.4rem;
+    height: 3.4rem;
+    font-size: 1.4rem;
+    border-radius: 9999px;
+    color: #fff;
+    background: linear-gradient(135deg, var(--privateaim-brand-coral), var(--privateaim-brand-purple));
+    box-shadow: 0 10px 22px -10px color-mix(in oklab, var(--privateaim-brand-purple) 80%, transparent);
+    transition: transform 0.25s ease;
+}
+
+.upload-dropzone:hover .upload-dropzone__icon {
+    transform: translateY(-2px) scale(1.04);
+}
+
+.upload-dropzone.is-dragover .upload-dropzone__icon {
+    animation: upload-bob 0.9s ease-in-out infinite;
+}
+
+@keyframes upload-bob {
+    0%, 100% { transform: translateY(-3px) scale(1.08); }
+    50% { transform: translateY(-7px) scale(1.08); }
+}
+
+.upload-dropzone__title {
+    position: relative;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--vc-color-fg);
+}
+
+.upload-dropzone__browse {
+    color: var(--vc-color-primary-600);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.upload-dropzone__hint {
+    position: relative;
+    font-size: 0.75rem;
+    color: var(--vc-color-fg-muted);
+}
+
+/* ============================================================
+   Selection summary + list
+   ============================================================ */
+.upload-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    color: var(--vc-color-fg-muted);
+}
+
+.upload-summary__count strong {
+    color: var(--vc-color-fg);
+}
+
+.upload-summary__size {
+    padding: 0.1rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: var(--vc-color-bg-muted);
+    border: 1px solid var(--vc-color-border);
+}
+
+.upload-summary__clear {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    border: 0;
+    background: transparent;
+    color: var(--vc-color-fg-muted);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.upload-summary__clear:hover:not(:disabled) {
+    color: var(--vc-color-error-500);
+}
+
+.upload-summary__clear:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.upload-file-list {
+    max-height: 220px;
+    overflow-y: auto;
+    padding-right: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .upload-dropzone,
+    .upload-dropzone__icon,
+    .upload-mode__btn {
+        transition: none;
+    }
+
+    .upload-dropzone.is-dragover .upload-dropzone__icon {
+        animation: none;
+    }
+}
+</style>


### PR DESCRIPTION
## Summary

The analysis file upload area used a bare Bootstrap `<input class="form-control">` that was barely visible against the content surface. This replaces it with a custom, theme-aware drag-and-drop dropzone.

### `FBucketFilesUpload.vue`
- **Custom drag-and-drop dropzone** — dashed border, gradient cloud-upload icon badge, brand wash on hover, solid coral border + lift + bobbing icon on drag-over.
- **Real drag-and-drop** — previously a file-picker only; now files can be dropped *or* browsed by clicking the zone.
- **Segmented Files / Directories toggle** replacing the old Bootstrap switch (active button keeps white text on hover; only the surface darkens).
- **Selection summary** — file count, total human-readable size, and a "Clear all" action, plus a scrollable file list.
- **Theme-native** — uses `--vc-color-*` / `--privateaim-brand-*` tokens, so it flips correctly between light and dark; respects `prefers-reduced-motion`.
- **Bug fixes** — the `:disbaled` typo (the input was never disabled while busy) and the buggy `vNode` reset hack; handlers are now properly typed (`Event` / `DragEvent` / `FileList`) instead of `any`.

### `eslint.config.js`
- Registered `globals.browser` for `**/*.vue`. The shared `@tada5hi/eslint-config` only sets Node globals for SFCs, so DOM-only globals (`DragEvent`, `FileList`, `HTMLInputElement`) tripped `no-undef`. `.ts` files in the package already had browser globals — this closes the gap for `.vue`.

## Test plan
- `npm run dev --workspace=apps/client-ui` → open an analysis → **Code Files** → **+** (Add) to open the upload modal.
- Verify in both light and dark mode: dropzone visibility, hover/drag-over states, mode toggle (active hover stays white), drag-and-drop a few files, the count/size summary, clear all, and upload.
- `npm run lint` passes.

## Notes
- Folder drag-and-drop drops only top-level files (`dataTransfer.files` doesn't recurse); full directory-tree uploads still use **Directories** mode + browse (`webkitdirectory`), as before.

closes #1186
closes #1155 
closes #1223
closes #1192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop upload support for both files and directories
  * Users can select multiple items with visual drag-over feedback
  * Displays a selection summary (item count and total size) and updates the Upload button label accordingly
  * Added a “Clear all” option to quickly reset selections

* **Improvements**
  * Improved how bucket file names are displayed by using available path information when present
<!-- end of auto-generated comment: release notes by coderabbit.ai -->