### PR TITLE
fix(realtime): deliver realtime updates for analysis & project node lists

### DIFF
--- a/apps/server-core/src/adapters/socket/controllers/analysis-node/handlers.ts
+++ b/apps/server-core/src/adapters/socket/controllers/analysis-node/handlers.ts
@@ -54,7 +54,7 @@ export function registerAnalysisNodeSocketHandlers(socket: Socket) {
     );
 
     socket.on(
-        buildDomainEventFullName(DomainType.ANALYSIS_NODE, DomainEventSubscriptionName.SUBSCRIBE),
+        buildDomainEventFullName(DomainType.ANALYSIS_NODE, DomainEventSubscriptionName.UNSUBSCRIBE),
         (target) => {
             unsubscribeSocketRoom(socket, buildDomainChannelName(DomainType.ANALYSIS_NODE, target));
         },
@@ -63,6 +63,11 @@ export function registerAnalysisNodeSocketHandlers(socket: Socket) {
 
 export function registerAnalysisNodeForRealmSocketHandlers(socket: Socket) {
     if (!isSocketAuthenticated(socket)) return;
+
+    // The realm namespace already isolates events by realm (analysis realm vs. node realm
+    // are distinct namespaces), so all directional subscriptions join the base entity room —
+    // the room the subscriber actually emits to. The in/out event names differ only to apply
+    // the correct permission gate (ANALYSIS_APPROVE for in, ANALYSIS_UPDATE for out).
 
     socket.on(
         buildDomainEventFullName(DomainSubType.ANALYSIS_NODE_IN, DomainEventSubscriptionName.SUBSCRIBE),
@@ -81,7 +86,7 @@ export function registerAnalysisNodeForRealmSocketHandlers(socket: Socket) {
                 return;
             }
 
-            subscribeSocketRoom(socket, buildDomainChannelName(DomainSubType.ANALYSIS_NODE_IN, target));
+            subscribeSocketRoom(socket, buildDomainChannelName(DomainType.ANALYSIS_NODE, target));
 
             if (isEventCallback(cb)) {
                 cb(null);
@@ -92,7 +97,7 @@ export function registerAnalysisNodeForRealmSocketHandlers(socket: Socket) {
     socket.on(
         buildDomainEventFullName(DomainSubType.ANALYSIS_NODE_IN, DomainEventSubscriptionName.UNSUBSCRIBE),
         (target) => {
-            unsubscribeSocketRoom(socket, buildDomainChannelName(DomainSubType.ANALYSIS_NODE_IN, target));
+            unsubscribeSocketRoom(socket, buildDomainChannelName(DomainType.ANALYSIS_NODE, target));
         },
     );
 
@@ -115,7 +120,7 @@ export function registerAnalysisNodeForRealmSocketHandlers(socket: Socket) {
                 return;
             }
 
-            subscribeSocketRoom(socket, buildDomainChannelName(DomainSubType.ANALYSIS_NODE_OUT, target));
+            subscribeSocketRoom(socket, buildDomainChannelName(DomainType.ANALYSIS_NODE, target));
 
             if (isEventCallback(cb)) {
                 cb(null);
@@ -126,7 +131,7 @@ export function registerAnalysisNodeForRealmSocketHandlers(socket: Socket) {
     socket.on(
         buildDomainEventFullName(DomainSubType.ANALYSIS_NODE_OUT, DomainEventSubscriptionName.UNSUBSCRIBE),
         (target) => {
-            unsubscribeSocketRoom(socket, buildDomainChannelName(DomainSubType.ANALYSIS_NODE_OUT, target));
+            unsubscribeSocketRoom(socket, buildDomainChannelName(DomainType.ANALYSIS_NODE, target));
         },
     );
 }

--- a/apps/server-core/src/adapters/socket/controllers/project-node/handlers.ts
+++ b/apps/server-core/src/adapters/socket/controllers/project-node/handlers.ts
@@ -66,6 +66,11 @@ export function registerProjectNodeSocketHandlers(socket: Socket) {
 export function registerProjectNodeForRealmSocketHandlers(socket: Socket) {
     if (!isSocketAuthenticated(socket)) return;
 
+    // The realm namespace already isolates events by realm (project realm vs. node realm
+    // are distinct namespaces), so all directional subscriptions join the base entity room —
+    // the room the subscriber actually emits to. The in/out event names differ only to apply
+    // the correct permission gate (PROJECT_APPROVE for in, PROJECT_UPDATE for out).
+
     // ------------------------------------------------------------
 
     socket.on(
@@ -87,7 +92,7 @@ export function registerProjectNodeForRealmSocketHandlers(socket: Socket) {
 
             subscribeSocketRoom(
                 socket,
-                buildDomainChannelName(DomainSubType.PROJECT_NODE_IN, target),
+                buildDomainChannelName(DomainType.PROJECT_NODE, target),
             );
 
             if (isEventCallback(cb)) {
@@ -101,7 +106,7 @@ export function registerProjectNodeForRealmSocketHandlers(socket: Socket) {
         (target) => {
             unsubscribeSocketRoom(
                 socket,
-                buildDomainChannelName(DomainSubType.PROJECT_NODE_IN, target),
+                buildDomainChannelName(DomainType.PROJECT_NODE, target),
             );
         },
     );
@@ -127,7 +132,7 @@ export function registerProjectNodeForRealmSocketHandlers(socket: Socket) {
 
             subscribeSocketRoom(
                 socket,
-                buildDomainChannelName(DomainSubType.PROJECT_NODE_OUT, target),
+                buildDomainChannelName(DomainType.PROJECT_NODE, target),
             );
 
             if (isEventCallback(cb)) {
@@ -141,7 +146,7 @@ export function registerProjectNodeForRealmSocketHandlers(socket: Socket) {
         (target) => {
             unsubscribeSocketRoom(
                 socket,
-                buildDomainChannelName(DomainSubType.PROJECT_NODE_OUT, target),
+                buildDomainChannelName(DomainType.PROJECT_NODE, target),
             );
         },
     );

--- a/packages/client-vue/src/components/analysis-node/FAnalysisNode.ts
+++ b/packages/client-vue/src/components/analysis-node/FAnalysisNode.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+    DomainEventSubscriptionName,
     DomainSubType,
     DomainType,
     buildDomainChannelName,
@@ -13,6 +14,7 @@ import {
 import type {
     AnalysisNode,
 } from '@privateaim/core-kit';
+import { buildDomainEventFullName } from '@privateaim/kit';
 import type { FiltersBuildInput } from 'rapiq';
 import {
     defineComponent,
@@ -82,16 +84,42 @@ export default defineComponent({
 
                     return false;
                 },
+                // Events are emitted to the base entity room within the realm namespace;
+                // realm scoping is enforced by the namespace and the realmId check above.
                 buildChannelName(id) {
-                    if (props.direction === Direction.IN) {
-                        return buildDomainChannelName(DomainSubType.ANALYSIS_NODE_IN, id);
-                    }
-
-                    if (props.direction === Direction.OUT) {
-                        return buildDomainChannelName(DomainSubType.ANALYSIS_NODE_OUT, id);
-                    }
-
                     return buildDomainChannelName(DomainType.ANALYSIS_NODE, id);
+                },
+                // Match the subscribe event to the namespace createEntitySocket connects to:
+                // directional handlers exist only in realm namespaces, the base handler only at root.
+                buildSubscribeEventName(realmId) {
+                    if (realmId) {
+                        return buildDomainEventFullName(
+                            props.direction === Direction.IN ?
+                                DomainSubType.ANALYSIS_NODE_IN :
+                                DomainSubType.ANALYSIS_NODE_OUT,
+                            DomainEventSubscriptionName.SUBSCRIBE,
+                        );
+                    }
+
+                    return buildDomainEventFullName(
+                        DomainType.ANALYSIS_NODE,
+                        DomainEventSubscriptionName.SUBSCRIBE,
+                    );
+                },
+                buildUnsubscribeEventName(realmId) {
+                    if (realmId) {
+                        return buildDomainEventFullName(
+                            props.direction === Direction.IN ?
+                                DomainSubType.ANALYSIS_NODE_IN :
+                                DomainSubType.ANALYSIS_NODE_OUT,
+                            DomainEventSubscriptionName.UNSUBSCRIBE,
+                        );
+                    }
+
+                    return buildDomainEventFullName(
+                        DomainType.ANALYSIS_NODE,
+                        DomainEventSubscriptionName.UNSUBSCRIBE,
+                    );
                 },
             },
         });

--- a/packages/client-vue/src/components/analysis-node/FAnalysisNodes.ts
+++ b/packages/client-vue/src/components/analysis-node/FAnalysisNodes.ts
@@ -13,7 +13,6 @@ import {
     DomainEventSubscriptionName,
     DomainSubType,
     DomainType,
-    buildDomainChannelName,
 } from '@privateaim/core-kit';
 import { buildDomainEventFullName, hasOwnProperty } from '@privateaim/kit';
 import type { PropType, SlotsType, VNodeChild } from 'vue';
@@ -57,21 +56,6 @@ export default defineComponent({
             DomainType.ANALYSIS :
             DomainType.NODE));
 
-        const isSameSocketRoom = (room?: string) => {
-            if (props.realmId) {
-                switch (props.direction) {
-                    case Direction.IN:
-                        return room === buildDomainChannelName(DomainSubType.ANALYSIS_NODE_IN);
-                    case Direction.OUT:
-                        return room === buildDomainChannelName(DomainSubType.ANALYSIS_NODE_OUT);
-                }
-            } else {
-                return room === buildDomainChannelName(DomainType.ANALYSIS_NODE);
-            }
-
-            return false;
-        };
-
         const isSocketEventForSource = (item: AnalysisNode) => {
             switch (source.value) {
                 case DomainType.NODE:
@@ -97,12 +81,17 @@ export default defineComponent({
             props,
             setup: ctx,
             socket: {
+                // Realm scoping is handled by the namespace and the base-room check in
+                // createEntitySocket; here we only confirm the event belongs to this source.
                 processEvent(event) {
-                    return isSameSocketRoom(event.meta.roomName) &&
-                        isSocketEventForSource(event.data);
+                    return isSocketEventForSource(event.data);
                 },
-                buildSubscribeEventName() {
-                    if (props.realmId) {
+                // Branch on the effective realmId (resolved by createEntitySocket — undefined
+                // for master-realm sockets on the root namespace), not props.realmId, so the
+                // subscribe event always matches the namespace the socket actually connects to:
+                // directional handlers live only in realm namespaces, the base handler only at root.
+                buildSubscribeEventName(realmId) {
+                    if (realmId) {
                         if (props.direction === Direction.IN) {
                             return buildDomainEventFullName(
                                 DomainSubType.ANALYSIS_NODE_IN,
@@ -121,8 +110,8 @@ export default defineComponent({
                         DomainEventSubscriptionName.SUBSCRIBE,
                     );
                 },
-                buildUnsubscribeEventName() {
-                    if (props.realmId) {
+                buildUnsubscribeEventName(realmId) {
+                    if (realmId) {
                         if (props.direction === Direction.IN) {
                             return buildDomainEventFullName(
                                 DomainSubType.ANALYSIS_NODE_IN,

--- a/packages/client-vue/src/components/project-node/FProjectNode.ts
+++ b/packages/client-vue/src/components/project-node/FProjectNode.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+    DomainEventSubscriptionName,
     DomainSubType,
     DomainType,
     buildDomainChannelName,
@@ -13,6 +14,7 @@ import {
 import type {
     ProjectNode,
 } from '@privateaim/core-kit';
+import { buildDomainEventFullName } from '@privateaim/kit';
 import type { FiltersBuildInput } from 'rapiq';
 import {
     defineComponent, 
@@ -72,25 +74,51 @@ export default defineComponent({
                     }
 
                     if (props.target === Target.PROJECT) {
-                        return realmId === event.data.node_realm_id;
+                        return realmId === event.data.project_realm_id;
                     }
 
                     if (props.target === Target.NODE) {
-                        return realmId === event.data.project_realm_id;
+                        return realmId === event.data.node_realm_id;
                     }
 
                     return false;
                 },
+                // Events are emitted to the base entity room within the realm namespace;
+                // realm scoping is enforced by the namespace and the realmId check above.
                 buildChannelName(id) {
-                    if (props.direction === Direction.IN) {
-                        return buildDomainChannelName(DomainSubType.PROJECT_NODE_IN, id);
-                    }
-
-                    if (props.direction === Direction.OUT) {
-                        return buildDomainChannelName(DomainSubType.PROJECT_NODE_OUT, id);
-                    }
-
                     return buildDomainChannelName(DomainType.PROJECT_NODE, id);
+                },
+                // Match the subscribe event to the namespace createEntitySocket connects to:
+                // directional handlers exist only in realm namespaces, the base handler only at root.
+                buildSubscribeEventName(realmId) {
+                    if (realmId) {
+                        return buildDomainEventFullName(
+                            props.direction === Direction.IN ?
+                                DomainSubType.PROJECT_NODE_IN :
+                                DomainSubType.PROJECT_NODE_OUT,
+                            DomainEventSubscriptionName.SUBSCRIBE,
+                        );
+                    }
+
+                    return buildDomainEventFullName(
+                        DomainType.PROJECT_NODE,
+                        DomainEventSubscriptionName.SUBSCRIBE,
+                    );
+                },
+                buildUnsubscribeEventName(realmId) {
+                    if (realmId) {
+                        return buildDomainEventFullName(
+                            props.direction === Direction.IN ?
+                                DomainSubType.PROJECT_NODE_IN :
+                                DomainSubType.PROJECT_NODE_OUT,
+                            DomainEventSubscriptionName.UNSUBSCRIBE,
+                        );
+                    }
+
+                    return buildDomainEventFullName(
+                        DomainType.PROJECT_NODE,
+                        DomainEventSubscriptionName.UNSUBSCRIBE,
+                    );
                 },
             },
         });

--- a/packages/client-vue/src/components/project-node/FProjectNodes.ts
+++ b/packages/client-vue/src/components/project-node/FProjectNodes.ts
@@ -13,7 +13,6 @@ import {
     DomainEventSubscriptionName,
     DomainSubType,
     DomainType,
-    buildDomainChannelName,
 } from '@privateaim/core-kit';
 import { buildDomainEventFullName, hasOwnProperty } from '@privateaim/kit';
 import type { RelationsBuildInput } from 'rapiq';
@@ -67,21 +66,6 @@ export default defineComponent({
             DomainType.PROJECT :
             DomainType.NODE));
 
-        const isSameSocketRoom = (room?: string) => {
-            if (props.realmId) {
-                switch (props.direction) {
-                    case Direction.IN:
-                        return room === buildDomainChannelName(DomainSubType.PROJECT_NODE_IN);
-                    case Direction.OUT:
-                        return room === buildDomainChannelName(DomainSubType.PROJECT_NODE_OUT);
-                }
-            } else {
-                return room === buildDomainChannelName(DomainType.PROJECT_NODE);
-            }
-
-            return false;
-        };
-
         const isSocketEventForSource = (item: ProjectNode) => {
             switch (source.value) {
                 case DomainType.NODE:
@@ -109,12 +93,17 @@ export default defineComponent({
             props,
             setup: ctx,
             socket: {
+                // Realm scoping is handled by the namespace and the base-room check in
+                // createEntitySocket; here we only confirm the event belongs to this source.
                 processEvent(event) {
-                    return isSameSocketRoom(event.meta.roomName) &&
-                        isSocketEventForSource(event.data);
+                    return isSocketEventForSource(event.data);
                 },
-                buildSubscribeEventName() {
-                    if (props.realmId) {
+                // Branch on the effective realmId (resolved by createEntitySocket — undefined
+                // for master-realm sockets on the root namespace), not props.realmId, so the
+                // subscribe event always matches the namespace the socket actually connects to:
+                // directional handlers live only in realm namespaces, the base handler only at root.
+                buildSubscribeEventName(realmId) {
+                    if (realmId) {
                         if (props.direction === Direction.IN) {
                             return buildDomainEventFullName(
                                 DomainSubType.PROJECT_NODE_IN,
@@ -133,8 +122,8 @@ export default defineComponent({
                         DomainEventSubscriptionName.SUBSCRIBE,
                     );
                 },
-                buildUnsubscribeEventName() {
-                    if (props.realmId) {
+                buildUnsubscribeEventName(realmId) {
+                    if (realmId) {
                         if (props.direction === Direction.IN) {
                             return buildDomainEventFullName(
                                 DomainSubType.PROJECT_NODE_IN,

--- a/packages/client-vue/src/core/entity-socket/module.ts
+++ b/packages/client-vue/src/core/entity-socket/module.ts
@@ -178,7 +178,7 @@ export function createEntitySocket<
         const socket = await socketManager.connect(buildDomainNamespaceName(realmId.value));
         let event : DomainEventFullName<string, DomainEventSubscriptionName> | undefined;
         if (ctx.buildSubscribeEventName) {
-            event = ctx.buildSubscribeEventName();
+            event = ctx.buildSubscribeEventName(realmId.value);
         } else {
             event = buildDomainEventFullName(
                 ctx.type,
@@ -221,7 +221,7 @@ export function createEntitySocket<
 
         let event : DomainEventFullName<string, DomainEventSubscriptionName>;
         if (ctx.buildUnsubscribeEventName) {
-            event = ctx.buildUnsubscribeEventName();
+            event = ctx.buildUnsubscribeEventName(realmId.value);
         } else {
             event = buildDomainEventFullName(
                 ctx.type,

--- a/packages/client-vue/src/core/entity-socket/type.ts
+++ b/packages/client-vue/src/core/entity-socket/type.ts
@@ -29,8 +29,8 @@ export type EntitySocketContext<
     refType?: () => string,
 
     buildChannelName?(entityId?: DomainEntityID<T>) : string;
-    buildSubscribeEventName?(): DomainEventFullName<string, DomainEventSubscriptionName>;
-    buildUnsubscribeEventName?(): DomainEventFullName<string, DomainEventSubscriptionName>;
+    buildSubscribeEventName?(realmId?: string): DomainEventFullName<string, DomainEventSubscriptionName>;
+    buildUnsubscribeEventName?(realmId?: string): DomainEventFullName<string, DomainEventSubscriptionName>;
 };
 
 export type EntitySocket = {


### PR DESCRIPTION
## Problem

Analysis- and project-node lists — including the **node-execution list** on the analysis view — never updated in realtime. New `execution_status`/approval changes only showed up after a manual reload.

## Root cause

In a realm namespace the client subscribed to and filtered on the **directional** socket rooms (`analysisNodeOut`/`In`, `projectNodeOut`/`In`), but the TypeORM subscriber only ever publishes to the **base** entity room (`analysisNode` / `projectNode`). Every realtime event was therefore delivered to a room nobody was listening in, and dropped.

The contradiction was actually twofold: the list's custom `isSameSocketRoom` check demanded the directional room while `createEntitySocket`'s built-in room check demanded the base room — so the realm+direction path could never match, regardless of what the server emitted.

## Approach

Realm isolation is already provided by the socket **namespace** (`/resources/<realmId>` — the analysis realm and node realm are distinct namespaces). The in/out split therefore only needs to gate **permissions**, not separate rooms. So all directional subscriptions now join the **base entity room** (the one the subscriber emits to), and the directional event names are kept solely for their permission checks (`ANALYSIS_APPROVE`/`ANALYSIS_UPDATE`, `PROJECT_APPROVE`/`PROJECT_UPDATE`).

## Changes

**Server (`server-core`)**
- Directional analysis-/project-node subscribe handlers now join the **base** room instead of `…Out`/`…In`.
- Fixed the analysis-node base handler whose *unsubscribe* listener was registered on the `SUBSCRIBE` event name (base subscribe joined then immediately left).

**Client (`client-vue`)**
- Lists (`FAnalysisNodes`, `FProjectNodes`): dropped the contradictory `isSameSocketRoom` check; `processEvent` now only confirms the event belongs to the viewed source.
- Per-item managers (`FAnalysisNode`, `FProjectNode`): `buildChannelName` now targets the base room.
- `createEntitySocket` passes the **effective** realmId into `buildSubscribe/UnsubscribeEventName`, so master-realm sockets (root namespace) emit the base subscribe and join the base room, while realm sockets emit the directional subscribe — the subscribe event now always matches the namespace the socket actually connects to.
- Fixed a `FProjectNode.processEvent` realm-field swap (`PROJECT`/`NODE` were comparing the wrong `*_realm_id`).

## Behavior after

- **Non-master user in their realm** (the reported case): node-execution list updates live.
- **Master user on the root namespace**: emits the base subscribe → joins the base room → receives the all-realm broadcast, narrowed client-side by `isSocketEventForSource`.

## Verification

- `eslint` clean on all touched files.
- `server-core` (tsc) and `client-vue` (vue-tsc) build/type-check.
- No tests reference the changed room names or builders.
- Manual: open an analysis's node-execution list as a realm user and trigger a node `execution_status` change — badge/progress update without reload.

## Follow-ups (not in this PR)

- Root-namespace **firehose**: master sockets decode every realm's node events and filter client-side. Correct, but could be narrowed server-side on busy instances.
- Per-item managers' sockets are redundant with the list socket when rendered inside a list (idempotent, but an optional opt-out prop could avoid N+1 subscriptions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed realm-level socket event handling for analysis nodes to properly distinguish between subscription and unsubscription events.
  * Corrected socket event routing for project and analysis nodes to ensure reliable real-time synchronization within scoped realm environments.
  * Improved event subscription consistency by refining how directional event types are handled across different realm scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->