### PR TITLE
feat(server-core): provision a dedicated Authup client per analysis

### DIFF
--- a/apps/server-core/src/adapters/database/entities/analysis.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Realm, User } from '@authup/core-kit';
+import type { Client, Realm, User } from '@authup/core-kit';
 import type {
     Analysis,
     MasterImage,
@@ -206,6 +206,11 @@ export class AnalysisEntity implements Analysis {
     @ManyToOne(() => RegistryEntity, { onDelete: 'CASCADE', nullable: true })
     @JoinColumn({ name: 'registry_id' })
     registry: RegistryEntity | null;
+
+    // ------------------------------------------------------------------
+
+    @Column({ type: 'uuid', nullable: true })
+    client_id: Client['id'] | null;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/migrations/mysql/1783000000000-AddAnalysisClientId.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1783000000000-AddAnalysisClientId.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAnalysisClientId1783000000000 implements MigrationInterface {
+    name = 'AddAnalysisClientId1783000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`analysis\` ADD \`client_id\` varchar(255) NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`analysis\` DROP COLUMN \`client_id\`
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1783000000000-AddAnalysisClientId.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1783000000000-AddAnalysisClientId.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAnalysisClientId1783000000000 implements MigrationInterface {
+    name = 'AddAnalysisClientId1783000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "analysis" ADD "client_id" uuid
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "analysis" DROP COLUMN "client_id"
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/subscribers/analysis/module.ts
+++ b/apps/server-core/src/adapters/database/subscribers/analysis/module.ts
@@ -6,18 +6,25 @@
  */
 
 import type {
+    EntityManager,
     EntitySubscriberInterface,
+    InsertEvent,
+    RemoveEvent,
+    UpdateEvent,
 } from 'typeorm';
 import { DomainType } from '@privateaim/core-kit';
 import { BaseSubscriber } from '@privateaim/server-db-kit';
 import type { EntityEventDestination } from '@privateaim/server-kit';
 import { DomainEventNamespace } from '@privateaim/kit';
 import { AnalysisEntity } from '../../entities/analysis.ts';
+import type { AnalysisClientService } from '../../../../app/modules/database/analysis-client.ts';
 
 export class AnalysisSubscriber extends BaseSubscriber<
     AnalysisEntity
 > implements EntitySubscriberInterface<AnalysisEntity> {
-    constructor() {
+    protected analysisClientService?: AnalysisClientService;
+
+    constructor(ctx?: { analysisClientService?: AnalysisClientService }) {
         super({
             refType: DomainType.ANALYSIS,
             destinations: (data) => {
@@ -48,6 +55,59 @@ export class AnalysisSubscriber extends BaseSubscriber<
                 return destinations;
             },
         });
+
+        this.analysisClientService = ctx?.analysisClientService;
+    }
+
+    async afterInsert(event: InsertEvent<AnalysisEntity>): Promise<any> {
+        await super.afterInsert(event);
+
+        await this.assignClient(event.entity, event.manager, true);
+    }
+
+    async afterUpdate(event: UpdateEvent<AnalysisEntity>): Promise<any> {
+        await super.afterUpdate(event);
+
+        await this.assignClient(
+            {
+                ...(event.databaseEntity || {}),
+                ...event.entity,
+            } as AnalysisEntity,
+            event.manager,
+            false,
+        );
+    }
+
+    async afterRemove(event: RemoveEvent<AnalysisEntity>): Promise<any> {
+        if (!this.analysisClientService) return;
+
+        await this.analysisClientService.dismiss(event.entity || event.databaseEntity);
+    }
+
+    /**
+     * Ensure the analysis owns an Authup client. On insert the default
+     * self-capabilities are granted; on update we only (re)create a missing
+     * client and never touch its permissions, so admin-configured capabilities
+     * (plan 010, phase 2) are preserved.
+     */
+    protected async assignClient(
+        entity: AnalysisEntity,
+        manager: EntityManager,
+        assignDefaultPermissions: boolean,
+    ): Promise<void> {
+        if (!this.analysisClientService) return;
+
+        const prevId = entity.client_id;
+
+        const client = await this.analysisClientService.assign(entity);
+        if (client.id !== prevId) {
+            const repository = manager.getRepository(AnalysisEntity);
+            await repository.save(entity);
+        }
+
+        if (assignDefaultPermissions) {
+            await this.analysisClientService.assignDefaultPermissions(client);
+        }
     }
 
     listenTo() {

--- a/apps/server-core/src/app/modules/database/analysis-client.ts
+++ b/apps/server-core/src/app/modules/database/analysis-client.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Client, Permission } from '@authup/core-kit';
+import { PermissionName } from '@privateaim/kit';
+import type { AuthupClient, Logger } from '@privateaim/server-kit';
+import { isClientErrorWithStatusCode } from 'hapic';
+import type { AnalysisEntity } from '../../../adapters/database/entities/index.ts';
+
+/**
+ * Self-capabilities granted to a freshly minted analysis client. They let the
+ * running analysis act on the node side under its own (restricted) identity.
+ * Assigned once, additively, on creation — admins refine the set per analysis
+ * later (plan 010, phase 2), so this service never removes permissions.
+ */
+const DEFAULT_PERMISSION_NAMES: string[] = [
+    PermissionName.ANALYSIS_SELF_STORAGE_USE,
+    PermissionName.ANALYSIS_SELF_MESSAGE_BROKER_USE,
+];
+
+export class AnalysisClientService {
+    protected authup: AuthupClient;
+
+    protected logger?: Logger;
+
+    constructor(authup: AuthupClient, logger?: Logger) {
+        this.authup = authup;
+        this.logger = logger;
+    }
+
+    async dismiss(entity: AnalysisEntity): Promise<void> {
+        if (!entity.client_id) {
+            return;
+        }
+
+        try {
+            await this.authup.client.delete(entity.client_id);
+        } catch (e) {
+            if (!isClientErrorWithStatusCode(e, 404)) {
+                throw e;
+            }
+        }
+
+        entity.client_id = null;
+    }
+
+    async assign(entity: AnalysisEntity): Promise<Client> {
+        let client: Client | undefined;
+
+        if (entity.client_id) {
+            try {
+                client = await this.authup.client.getOne(entity.client_id);
+            } catch (e) {
+                if (!isClientErrorWithStatusCode(e, 404)) {
+                    throw e;
+                }
+            }
+        }
+
+        if (!client) {
+            client = await this.authup.client.create({
+                name: entity.id,
+                realm_id: entity.realm_id,
+                is_confidential: true,
+            });
+
+            entity.client_id = client.id;
+        }
+
+        return client;
+    }
+
+    /**
+     * Additively grant the default self-capabilities to the analysis client.
+     * Existing client permissions are never removed (unlike the node client),
+     * so an admin's later refinements survive subsequent calls.
+     */
+    async assignDefaultPermissions(client: Client): Promise<void> {
+        const { data: clientPermissions } = await this.authup
+            .clientPermission.getMany({
+                relations: { permission: true },
+                filter: { client_id: client.id },
+            });
+
+        const permissionNamesAssigned = clientPermissions.map(
+            (clientPermission) => clientPermission.permission.name,
+        );
+
+        for (const permissionName of DEFAULT_PERMISSION_NAMES) {
+            if (permissionNamesAssigned.includes(permissionName)) {
+                continue;
+            }
+
+            let permission: Permission | undefined;
+
+            try {
+                permission = await this.authup.permission.getOne(permissionName);
+            } catch (e) {
+                if (!isClientErrorWithStatusCode(e, 404)) {
+                    throw e;
+                }
+
+                this.logger?.warn(`The analysis-client permission could not be created, due non existing permission ${permissionName}.`);
+            }
+
+            if (permission) {
+                await this.authup.clientPermission.create({
+                    client_id: client.id,
+                    permission_id: permission.id,
+                });
+            }
+        }
+    }
+}

--- a/apps/server-core/src/app/modules/database/module.ts
+++ b/apps/server-core/src/app/modules/database/module.ts
@@ -34,6 +34,7 @@ import {
     RegistrySubscriber,
 } from '../../../adapters/database/subscribers/index.ts';
 import { NodeClientService } from './node-client.ts';
+import { AnalysisClientService } from './analysis-client.ts';
 import { DataSourceOptionsBuilder } from './options.ts';
 import { DatabaseInjectionKey } from './constants.ts';
 import { registerRepositories } from './register.ts';
@@ -97,14 +98,16 @@ export class DatabaseModule implements IModule {
 
     private registerSubscribers(dataSource: DataSource, container: IContainer): void {
         let nodeClientService: NodeClientService | undefined;
+        let analysisClientService: AnalysisClientService | undefined;
         const authupResult = container.tryResolve(AuthupClientInjectionKey);
         if (authupResult.success) {
             nodeClientService = new NodeClientService(authupResult.data);
+            analysisClientService = new AnalysisClientService(authupResult.data);
         }
 
         const subscribers = [
             new NodeSubscriber({ nodeClientService }),
-            new AnalysisSubscriber(),
+            new AnalysisSubscriber({ analysisClientService }),
             new AnalysisBucketFileSubscriber(),
             new AnalysisNodeSubscriber(),
 

--- a/apps/server-core/src/app/modules/database/repositories/analysis/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/analysis/repository.ts
@@ -52,6 +52,7 @@ const DEFAULT_FIELDS: ParseAllowedOption<AnalysisEntity> = [
     'created_at',
     'updated_at',
     'registry_id',
+    'client_id',
     'realm_id',
     'user_id',
     'project_id',

--- a/apps/server-core/test/unit/adapters/database/subscribers/analysis/analysis-subscriber.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/subscribers/analysis/analysis-subscriber.spec.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Client } from '@authup/core-kit';
+import { describe, expect, it } from 'vitest';
+import { AnalysisSubscriber } from '../../../../../../src/adapters/database/subscribers/analysis/module.ts';
+import type { AnalysisClientService } from '../../../../../../src/app/modules/database/analysis-client.ts';
+
+type DismissCall = { entity: Record<string, any> };
+type AssignCall = { entity: Record<string, any> };
+type AssignDefaultPermissionsCall = { client: Client };
+
+class FakeAnalysisClientService {
+    private dismissCalls: DismissCall[] = [];
+
+    private assignCalls: AssignCall[] = [];
+
+    private assignDefaultPermissionsCalls: AssignDefaultPermissionsCall[] = [];
+
+    private nextClientId = 'client-1';
+
+    async dismiss(entity: Record<string, any>): Promise<void> {
+        this.dismissCalls.push({ entity });
+        entity.client_id = null;
+    }
+
+    async assign(entity: Record<string, any>): Promise<Client> {
+        this.assignCalls.push({ entity });
+        entity.client_id = this.nextClientId;
+        return { id: this.nextClientId } as Client;
+    }
+
+    async assignDefaultPermissions(client: Client): Promise<void> {
+        this.assignDefaultPermissionsCalls.push({ client });
+    }
+
+    getDismissCalls(): DismissCall[] {
+        return [...this.dismissCalls];
+    }
+
+    getAssignCalls(): AssignCall[] {
+        return [...this.assignCalls];
+    }
+
+    getAssignDefaultPermissionsCalls(): AssignDefaultPermissionsCall[] {
+        return [...this.assignDefaultPermissionsCalls];
+    }
+}
+
+function createMockRemoveEvent(overrides: Record<string, any> = {}) {
+    return {
+        entity: {
+            id: randomUUID(),
+            client_id: 'existing-client',
+            realm_id: randomUUID(),
+        },
+        databaseEntity: null,
+        queryRunner: { data: {} },
+        ...overrides,
+    };
+}
+
+function createMockInsertEvent(overrides: Record<string, any> = {}) {
+    const entityId = randomUUID();
+    return {
+        entity: {
+            id: entityId,
+            client_id: null,
+            realm_id: randomUUID(),
+        },
+        queryRunner: { data: {} },
+        manager: { getRepository: () => ({ save: async (e: Record<string, any>) => e }) },
+        ...overrides,
+    };
+}
+
+function createMockUpdateEvent(overrides: Record<string, any> = {}) {
+    const entityId = randomUUID();
+    return {
+        entity: {
+            id: entityId,
+            client_id: null,
+            realm_id: randomUUID(),
+        },
+        databaseEntity: { id: entityId },
+        queryRunner: { data: {} },
+        manager: { getRepository: () => ({ save: async (e: Record<string, any>) => e }) },
+        ...overrides,
+    };
+}
+
+describe('AnalysisSubscriber', () => {
+    describe('afterRemove', () => {
+        it('should call analysisClientService.dismiss when service is set', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            const event = createMockRemoveEvent();
+            await subscriber.afterRemove(event as any);
+
+            expect(analysisClientService.getDismissCalls()).toHaveLength(1);
+            expect(analysisClientService.getDismissCalls()[0].entity).toBe(event.entity);
+        });
+
+        it('should not throw when analysisClientService is not set', async () => {
+            const subscriber = new AnalysisSubscriber();
+
+            const event = createMockRemoveEvent();
+            await subscriber.afterRemove(event as any);
+            // no error — graceful no-op
+        });
+    });
+
+    describe('afterInsert', () => {
+        it('should call analysisClientService.assign when service is set', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            const event = createMockInsertEvent();
+            await subscriber.afterInsert(event as any);
+
+            expect(analysisClientService.getAssignCalls()).toHaveLength(1);
+        });
+
+        it('should assign the default permissions after assign', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            const event = createMockInsertEvent();
+            await subscriber.afterInsert(event as any);
+
+            expect(analysisClientService.getAssignDefaultPermissionsCalls()).toHaveLength(1);
+            expect(analysisClientService.getAssignDefaultPermissionsCalls()[0].client.id).toBe('client-1');
+        });
+
+        it('should not throw when analysisClientService is not set', async () => {
+            const subscriber = new AnalysisSubscriber();
+
+            const event = createMockInsertEvent();
+            await subscriber.afterInsert(event as any);
+        });
+    });
+
+    describe('afterUpdate', () => {
+        it('should call analysisClientService.assign with merged entity', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            const event = createMockUpdateEvent();
+            await subscriber.afterUpdate(event as any);
+
+            expect(analysisClientService.getAssignCalls()).toHaveLength(1);
+        });
+
+        it('should NOT re-assign the default permissions on update', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            const event = createMockUpdateEvent();
+            await subscriber.afterUpdate(event as any);
+
+            // The key divergence from the node client: updating an analysis must
+            // never re-sync permissions, so admin-configured capabilities survive.
+            expect(analysisClientService.getAssignDefaultPermissionsCalls()).toHaveLength(0);
+        });
+
+        it('should save entity when client_id changes', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            let savedEntity: Record<string, any> | undefined;
+            const event = createMockUpdateEvent({
+                entity: {
+                    id: randomUUID(),
+                    client_id: null,
+                    realm_id: randomUUID(),
+                },
+                manager: { getRepository: () => ({ save: async (e: Record<string, any>) => { savedEntity = e; return e; } }) },
+            });
+            await subscriber.afterUpdate(event as any);
+
+            expect(savedEntity).toBeDefined();
+            expect(savedEntity!.client_id).toBe('client-1');
+        });
+
+        it('should not save entity when client_id is unchanged', async () => {
+            const analysisClientService = new FakeAnalysisClientService();
+            const subscriber = new AnalysisSubscriber({ analysisClientService: analysisClientService as unknown as AnalysisClientService });
+
+            let saveCalled = false;
+            const event = createMockUpdateEvent({
+                entity: {
+                    id: randomUUID(),
+                    client_id: 'client-1',
+                    realm_id: randomUUID(),
+                },
+                manager: { getRepository: () => ({ save: async (e: Record<string, any>) => { saveCalled = true; return e; } }) },
+            });
+            await subscriber.afterUpdate(event as any);
+
+            expect(saveCalled).toBe(false);
+        });
+
+        it('should not throw when analysisClientService is not set', async () => {
+            const subscriber = new AnalysisSubscriber();
+
+            const event = createMockUpdateEvent();
+            await subscriber.afterUpdate(event as any);
+        });
+    });
+});

--- a/apps/server-core/test/unit/app/modules/database/analysis-client.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/analysis-client.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { PermissionName } from '@privateaim/kit';
+import type { AuthupClient } from '@privateaim/server-kit';
+import { describe, expect, it } from 'vitest';
+import { AnalysisClientService } from '../../../../../src/app/modules/database/analysis-client.ts';
+
+type ClientPermissionRecord = { id: string; permission: { name: string } };
+
+/**
+ * In-memory fake of the parts of AuthupClient the AnalysisClientService touches.
+ * Records calls so assertions can verify create/reuse/dismiss and the additive
+ * (never-delete) permission behaviour.
+ */
+class FakeAuthupClient {
+    public createdClients: Record<string, any>[] = [];
+
+    public deletedClientIds: string[] = [];
+
+    public createdClientPermissions: Record<string, any>[] = [];
+
+    public deletedClientPermissionIds: string[] = [];
+
+    private existingClients = new Map<string, { id: string }>();
+
+    private existingClientPermissions: ClientPermissionRecord[] = [];
+
+    private knownPermissions = new Set<string>();
+
+    private clientSeq = 0;
+
+    constructor(opts: {
+        permissions?: string[];
+        existingClient?: { id: string };
+        existingClientPermissions?: ClientPermissionRecord[];
+    } = {}) {
+        for (const name of opts.permissions || []) {
+            this.knownPermissions.add(name);
+        }
+        if (opts.existingClient) {
+            this.existingClients.set(opts.existingClient.id, opts.existingClient);
+        }
+        if (opts.existingClientPermissions) {
+            this.existingClientPermissions = opts.existingClientPermissions;
+        }
+    }
+
+    client = {
+        create: async (data: Record<string, any>) => {
+            this.clientSeq += 1;
+            const client = { id: `client-${this.clientSeq}` };
+            this.createdClients.push(data);
+            this.existingClients.set(client.id, client);
+            return client;
+        },
+        getOne: async (id: string) => {
+            const client = this.existingClients.get(id);
+            if (!client) {
+                throw new Error(`client ${id} not found`);
+            }
+            return client;
+        },
+        delete: async (id: string) => {
+            this.deletedClientIds.push(id);
+            this.existingClients.delete(id);
+            return { id };
+        },
+    };
+
+    clientPermission = {
+        getMany: async () => ({ data: this.existingClientPermissions }),
+        create: async (data: Record<string, any>) => {
+            this.createdClientPermissions.push(data);
+            return { id: `cp-${this.createdClientPermissions.length}`, ...data };
+        },
+        delete: async (id: string) => {
+            this.deletedClientPermissionIds.push(id);
+            return { id };
+        },
+    };
+
+    permission = {
+        getOne: async (name: string) => {
+            if (!this.knownPermissions.has(name)) {
+                throw new Error(`permission ${name} not found`);
+            }
+            return { id: `perm-${name}`, name };
+        },
+    };
+}
+
+function createAnalysisEntity(overrides: Record<string, any> = {}) {
+    return {
+        id: randomUUID(),
+        client_id: null,
+        realm_id: randomUUID(),
+        ...overrides,
+    } as any;
+}
+
+describe('AnalysisClientService', () => {
+    describe('assign', () => {
+        it('should create a confidential client and store its id when none exists', async () => {
+            const authup = new FakeAuthupClient();
+            const service = new AnalysisClientService(authup as unknown as AuthupClient);
+
+            const entity = createAnalysisEntity();
+            const client = await service.assign(entity);
+
+            expect(authup.createdClients).toHaveLength(1);
+            expect(authup.createdClients[0]).toMatchObject({
+                name: entity.id,
+                realm_id: entity.realm_id,
+                is_confidential: true,
+            });
+            expect(client.id).toBe('client-1');
+            expect(entity.client_id).toBe('client-1');
+        });
+
+        it('should reuse an existing client without creating a new one', async () => {
+            const authup = new FakeAuthupClient({ existingClient: { id: 'client-existing' } });
+            const service = new AnalysisClientService(authup as unknown as AuthupClient);
+
+            const entity = createAnalysisEntity({ client_id: 'client-existing' });
+            const client = await service.assign(entity);
+
+            expect(authup.createdClients).toHaveLength(0);
+            expect(client.id).toBe('client-existing');
+            expect(entity.client_id).toBe('client-existing');
+        });
+    });
+
+    describe('dismiss', () => {
+        it('should delete the client and clear the id', async () => {
+            const authup = new FakeAuthupClient({ existingClient: { id: 'client-x' } });
+            const service = new AnalysisClientService(authup as unknown as AuthupClient);
+
+            const entity = createAnalysisEntity({ client_id: 'client-x' });
+            await service.dismiss(entity);
+
+            expect(authup.deletedClientIds).toEqual(['client-x']);
+            expect(entity.client_id).toBeNull();
+        });
+
+        it('should be a no-op when there is no client_id', async () => {
+            const authup = new FakeAuthupClient();
+            const service = new AnalysisClientService(authup as unknown as AuthupClient);
+
+            const entity = createAnalysisEntity({ client_id: null });
+            await service.dismiss(entity);
+
+            expect(authup.deletedClientIds).toHaveLength(0);
+        });
+    });
+
+    describe('assignDefaultPermissions', () => {
+        it('should grant both self-capabilities to a client with none', async () => {
+            const authup = new FakeAuthupClient({
+                permissions: [
+                    PermissionName.ANALYSIS_SELF_STORAGE_USE,
+                    PermissionName.ANALYSIS_SELF_MESSAGE_BROKER_USE,
+                ],
+            });
+            const service = new AnalysisClientService(authup as unknown as AuthupClient);
+
+            await service.assignDefaultPermissions({ id: 'client-1' } as any);
+
+            const created = authup.createdClientPermissions.map((cp) => cp.permission_id);
+            expect(created).toContain(`perm-${PermissionName.ANALYSIS_SELF_STORAGE_USE}`);
+            expect(created).toContain(`perm-${PermissionName.ANALYSIS_SELF_MESSAGE_BROKER_USE}`);
+            expect(authup.createdClientPermissions).toHaveLength(2);
+        });
+
+        it('should additively add only the missing permission and never delete', async () => {
+            const authup = new FakeAuthupClient({
+                permissions: [
+                    PermissionName.ANALYSIS_SELF_STORAGE_USE,
+                    PermissionName.ANALYSIS_SELF_MESSAGE_BROKER_USE,
+                ],
+                existingClientPermissions: [
+                    { id: 'cp-existing', permission: { name: PermissionName.ANALYSIS_SELF_STORAGE_USE } },
+                ],
+            });
+            const service = new AnalysisClientService(authup as unknown as AuthupClient);
+
+            await service.assignDefaultPermissions({ id: 'client-1' } as any);
+
+            expect(authup.createdClientPermissions).toHaveLength(1);
+            expect(authup.createdClientPermissions[0].permission_id).toBe(`perm-${PermissionName.ANALYSIS_SELF_MESSAGE_BROKER_USE}`);
+            expect(authup.deletedClientPermissionIds).toHaveLength(0);
+        });
+    });
+});

--- a/packages/core-kit/src/domains/analysis/entity.ts
+++ b/packages/core-kit/src/domains/analysis/entity.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Realm, User } from '@authup/core-kit';
+import type { Client, Realm, User } from '@authup/core-kit';
 import type { ProcessStatus } from '@privateaim/kit';
 import type { MasterImage, MasterImageCommandArgument } from '../master-image';
 import type { Project } from '../project';
@@ -122,6 +122,14 @@ export interface Analysis {
     registry: Registry;
 
     registry_id: Registry['id'];
+
+    // ------------------------------------------------------------------
+
+    /**
+     * Dedicated OAuth2/Authup client the analysis uses to act on the node side
+     * under its own (restricted) identity. Provisioned on creation.
+     */
+    client_id: Client['id'] | null;
 
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## What

**Phase 1 of plan 010** (per-analysis Authup client). Each analysis now owns a dedicated confidential Authup client so the running analysis can act *on the node side* under its **own restricted identity**, instead of borrowing a broader identity. This mirrors the existing per-**node** client pattern (`NodeClientService` / `NodeSubscriber`) almost exactly — with one deliberate divergence (below).

Follow-up to #1692 (which removed the inert `AnalysisPermission` entity).

## Changes

- **Schema:** nullable `analysis.client_id` column + migration (Postgres `uuid` / MySQL `varchar(255)`); exposed on the `Analysis` type and the repository's default fields.
- **`AnalysisClientService`** (sibling of `NodeClientService`): create-or-reuse a confidential client named after the analysis id, `dismiss` on removal, and **additively** grant the default self-capabilities (`analysis_self_storage_use`, `analysis_self_message_broker_use`).
- **`AnalysisSubscriber`** wiring: grant defaults on insert, (re)create a missing client on update, dismiss on remove. Provisioning is a graceful no-op when no Authup client is configured (so the test/local paths are unaffected).
- **Tests:** `AnalysisClientService` (create / reuse / dismiss / additive permissions) and `AnalysisSubscriber` (full lifecycle).

## Deliberate divergence from the node client

`NodeClientService.assignPermissions` **force-syncs** (adds missing, deletes extras) on every insert *and* update. The analysis client instead:
- grants defaults **only on insert**, and
- on **update** only (re)creates a missing client — it **never re-syncs permissions**.

This is so the admin-configurable capabilities coming in **phase 2** aren't clobbered by an unrelated analysis update. There's an explicit unit test locking this in (`should NOT re-assign the default permissions on update`).

## Decision baked in (flag if you disagree)

New clients ship with **both** self-capabilities **enabled** (functional out of the box); phase 2 adds the admin surface to refine them per analysis. Switching to opt-in (none-by-default) is a one-line change to `DEFAULT_PERMISSION_NAMES`.

## Not in this PR

- Admin UI to toggle capabilities (phase 2).
- Delivering the client credentials to the node runtime (phase 3) — that's when this becomes user-visible, so docs land then.

## Validation

- `nx build` (core-kit, core-http-kit, server-core — incl. `tsc` decls + swagger gen) — green
- `nx test server-core` — **347** pass (36 files; +16 new tests)
- ESLint — green
- The new migration's `run → revert → run` cycle on real MySQL/Postgres is exercised by the `tests-migrations` CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analyses now support dedicated client associations that are automatically created and configured upon analysis creation with default permissions applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->