### PR TITLE
feat(server-core): admin-configurable analysis client capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ Modernization and refactoring plans:
 7. ~~Message Bus~~ — Complete (QueueRouter → MessageBus, AMQP/Memory driver abstraction)
 8. ~~[Shared Test Infrastructure](.agents/plans/008-shared-test-infrastructure.md)~~ — Complete (server-test-kit package, shared core types in server-kit, domain-grouped test layout)
 9. [Analysis Check Hardening](.agents/plans/009-analysis-check-hardening.md) — Proposed (race-safe check verdicts, worker ports + verdict unit tests, registry error classification, check observability)
-10. [Per-Analysis Authup Client](.agents/plans/010-analysis-dedicated-client.md) — Proposed (dedicated OAuth2 client per analysis mirroring the Node pattern, admin-configurable self-capabilities, node-side credential delivery, removal of the AnalysisPermission entity; future capability-token model for storage sharing)
+10. [Per-Analysis Authup Client](.agents/plans/010-analysis-dedicated-client.md) — In progress (dedicated OAuth2 client per analysis mirroring the Node pattern; phase 4 removed the AnalysisPermission entity (#1692, merged), phase 1 added `analysis.client_id` + `AnalysisClientService` (#1693); remaining: phase 2 admin-configurable capabilities, phase 3 node-side credential delivery)
+11. [Analysis Capability Tokens](.agents/plans/012-analysis-capability-tokens.md) — Proposed (resource-scoped, Google-Docs-style capability tokens issued by server-core so analyses can use storage/telemetry/messenger only for owned-or-shared resources; split out of plan 010's phase 5)
 
 ## Commits
 

--- a/apps/server-core/src/adapters/http/controllers/entities/analysis-client-permission/index.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/analysis-client-permission/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module.ts';

--- a/apps/server-core/src/adapters/http/controllers/entities/analysis-client-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/analysis-client-permission/module.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    DBody,
+    DContext,
+    DController,
+    DDelete,
+    DGet,
+    DPath,
+    DPost,
+    DTags,
+} from '@routup/decorators';
+import type { IAppEvent } from 'routup';
+import { ForceLoggedInMiddleware } from '@privateaim/server-http-kit';
+import type { AnalysisClientPermissionService } from '../../../../../app/modules/database/analysis-client-permission.ts';
+import { buildActorContext } from '../../../request/index.ts';
+
+type AnalysisClientPermissionControllerContext = {
+    service: AnalysisClientPermissionService;
+};
+
+@DTags('analysis')
+@DController('/analyses')
+export class AnalysisClientPermissionController {
+    protected service: AnalysisClientPermissionService;
+
+    constructor(ctx: AnalysisClientPermissionControllerContext) {
+        this.service = ctx.service;
+    }
+
+    @DGet('/:id/client/permissions', [ForceLoggedInMiddleware])
+    async getMany(
+        @DPath('id') id: string,
+        @DContext() event: IAppEvent,
+    ) {
+        const actor = buildActorContext(event);
+        const { data, meta } = await this.service.getMany(id, actor);
+        return { data, meta };
+    }
+
+    @DPost('/:id/client/permissions', [ForceLoggedInMiddleware])
+    async add(
+        @DPath('id') id: string,
+        @DBody() data: { permission_id: string },
+        @DContext() event: IAppEvent,
+    ) {
+        const actor = buildActorContext(event);
+        const entity = await this.service.create(id, data, actor);
+        event.response.status = 201;
+        return entity;
+    }
+
+    @DDelete('/:id/client/permissions/:permissionId', [ForceLoggedInMiddleware])
+    async drop(
+        @DPath('id') id: string,
+        @DPath('permissionId') permissionId: string,
+        @DContext() event: IAppEvent,
+    ) {
+        const actor = buildActorContext(event);
+        const entity = await this.service.delete(id, permissionId, actor);
+        event.response.status = 202;
+        return entity;
+    }
+}

--- a/apps/server-core/src/adapters/http/controllers/entities/index.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/index.ts
@@ -8,6 +8,7 @@
 export * from './analysis/index.ts';
 export * from './analysis-bucket/index.ts';
 export * from './analysis-bucket-file/index.ts';
+export * from './analysis-client-permission/index.ts';
 export * from './analysis-log/index.ts';
 export * from './analysis-node/index.ts';
 export * from './analysis-node-event/index.ts';

--- a/apps/server-core/src/app/modules/database/analysis-client-permission.ts
+++ b/apps/server-core/src/app/modules/database/analysis-client-permission.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Analysis } from '@privateaim/core-kit';
+import type { ClientPermission } from '@authup/core-kit';
+import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { PermissionName, isRealmResourceWritable } from '@privateaim/kit';
+import { BadRequestError, EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
+import type { ActorContext, AuthupClient } from '@privateaim/server-kit';
+import type { IAnalysisRepository } from '../../../core/index.ts';
+
+/**
+ * Capabilities that may be granted to an analysis' dedicated client. Restricting
+ * grants to this family means an analysis client can never be handed a broad
+ * permission (e.g. ANALYSIS_APPROVE) through this admin surface — it can only
+ * ever receive the self-scoped capabilities it uses on the node side.
+ */
+const ANALYSIS_SELF_PERMISSION_NAMES: string[] = [
+    PermissionName.ANALYSIS_SELF_STORAGE_USE,
+    PermissionName.ANALYSIS_SELF_MESSAGE_BROKER_USE,
+];
+
+type AnalysisClientPermissionServiceContext = {
+    authup: AuthupClient;
+    analysisRepository: IAnalysisRepository;
+};
+
+/**
+ * Manages the client-permission assignments of an analysis' dedicated Authup
+ * client (plan 010, phase 2). The analysis client itself is the source of truth
+ * — there is no hub-side join entity — so this is a thin, guarded pass-through
+ * to Authup's clientPermission API, constrained to the analysis-self family.
+ */
+export class AnalysisClientPermissionService {
+    protected authup: AuthupClient;
+
+    protected analysisRepository: IAnalysisRepository;
+
+    constructor(ctx: AnalysisClientPermissionServiceContext) {
+        this.authup = ctx.authup;
+        this.analysisRepository = ctx.analysisRepository;
+    }
+
+    protected async resolveAnalysis(analysisId: string): Promise<Analysis> {
+        const analysis = await this.analysisRepository.findOneById(analysisId);
+        if (!analysis) {
+            throw new EntityNotFoundError({ entity: 'analysis' });
+        }
+
+        return analysis;
+    }
+
+    /**
+     * Gate writes: the actor must hold ANALYSIS_UPDATE (globally and for this
+     * analysis' attributes), be allowed to write the analysis' realm, the
+     * analysis must not be configuration-locked, and a client must exist.
+     */
+    protected async assertWritable(analysis: Analysis, actor: ActorContext): Promise<void> {
+        await actor.permissionChecker.preCheck({ name: PermissionName.ANALYSIS_UPDATE });
+        await actor.permissionChecker.check({
+            name: PermissionName.ANALYSIS_UPDATE,
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: analysis }),
+        });
+
+        if (!isRealmResourceWritable(actor.realm, analysis.realm_id)) {
+            throw new PermissionDeniedError();
+        }
+
+        if (analysis.configuration_locked) {
+            throw new BadRequestError('The capabilities cannot be changed while the analysis configuration is locked.');
+        }
+
+        if (!analysis.client_id) {
+            throw new BadRequestError('The analysis has no client provisioned yet.');
+        }
+    }
+
+    async getMany(analysisId: string, actor: ActorContext) {
+        const analysis = await this.resolveAnalysis(analysisId);
+
+        // Viewing the capability assignments exposes the analysis' security
+        // configuration, so it requires the same permission as changing it.
+        await actor.permissionChecker.preCheck({ name: PermissionName.ANALYSIS_UPDATE });
+
+        if (!analysis.client_id) {
+            return { data: [], meta: { total: 0 } };
+        }
+
+        const { data, meta } = await this.authup.clientPermission.getMany({
+            filter: { client_id: analysis.client_id },
+            relations: { permission: true },
+        });
+
+        return { data, meta };
+    }
+
+    async create(analysisId: string, data: { permission_id?: string }, actor: ActorContext): Promise<ClientPermission> {
+        if (!data.permission_id) {
+            throw new BadRequestError('A permission_id is required.');
+        }
+
+        const analysis = await this.resolveAnalysis(analysisId);
+        await this.assertWritable(analysis, actor);
+
+        const permission = await this.authup.permission.getOne(data.permission_id);
+        if (!ANALYSIS_SELF_PERMISSION_NAMES.includes(permission.name)) {
+            throw new PermissionDeniedError('Only analysis self-capabilities can be assigned to an analysis client.');
+        }
+
+        return this.authup.clientPermission.create({
+            client_id: analysis.client_id,
+            permission_id: permission.id,
+        });
+    }
+
+    async delete(analysisId: string, permissionId: string, actor: ActorContext): Promise<ClientPermission> {
+        const analysis = await this.resolveAnalysis(analysisId);
+        await this.assertWritable(analysis, actor);
+
+        const { data } = await this.authup.clientPermission.getMany({ filter: { client_id: analysis.client_id, permission_id: permissionId } });
+
+        const [clientPermission] = data;
+        if (!clientPermission) {
+            throw new EntityNotFoundError({ entity: 'clientPermission' });
+        }
+
+        await this.authup.clientPermission.delete(clientPermission.id);
+
+        return clientPermission;
+    }
+}

--- a/apps/server-core/src/app/modules/http/controller.ts
+++ b/apps/server-core/src/app/modules/http/controller.ts
@@ -10,7 +10,7 @@ import {
     MasterImageBuilderComponentCaller,
     MasterImageSynchronizerComponentCaller,
 } from '@privateaim/server-core-worker-kit';
-import { MessageBusInjectionKey } from '@privateaim/server-kit';
+import { AuthupClientInjectionKey, MessageBusInjectionKey } from '@privateaim/server-kit';
 import {
     AnalysisBucketFileService,
     AnalysisBucketService,
@@ -37,6 +37,8 @@ import { AnalysisBucketFileController } from '../../../adapters/http/controllers
 import { ProjectNodeController } from '../../../adapters/http/controllers/entities/project-node/module.ts';
 import { AnalysisNodeController } from '../../../adapters/http/controllers/entities/analysis-node/module.ts';
 import { AnalysisNodeEventController } from '../../../adapters/http/controllers/entities/analysis-node-event/module.ts';
+import { AnalysisClientPermissionController } from '../../../adapters/http/controllers/entities/analysis-client-permission/module.ts';
+import { AnalysisClientPermissionService } from '../database/analysis-client-permission.ts';
 import { ServiceController } from '../../../adapters/http/controllers/workflows/service/index.ts';
 import { DatabaseInjectionKey } from '../database/constants.ts';
 import { AnalysisInjectionKey } from '../analysis/constants.ts';
@@ -139,6 +141,17 @@ export function createControllers(container: IContainer): Record<string, any>[] 
             registryService,
             registryCaller: callerResult.data,
         }));
+    }
+
+    // The analysis-client capability surface manages Authup client-permissions
+    // directly, so it is only mounted when an Authup client is available.
+    const authupResult = container.tryResolve(AuthupClientInjectionKey);
+    if (authupResult.success) {
+        const analysisClientPermissionService = new AnalysisClientPermissionService({
+            authup: authupResult.data,
+            analysisRepository,
+        });
+        controllers.push(new AnalysisClientPermissionController({ service: analysisClientPermissionService }));
     }
 
     return controllers;

--- a/apps/server-core/test/unit/app/modules/database/analysis-client-permission.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/analysis-client-permission.spec.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Analysis } from '@privateaim/core-kit';
+import { PermissionName } from '@privateaim/kit';
+import { BadRequestError, EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
+import type { AuthupClient } from '@privateaim/server-kit';
+import { createAllowAllActor, createDenyAllActor } from '@privateaim/server-test-kit';
+import { describe, expect, it } from 'vitest';
+import { AnalysisClientPermissionService } from '../../../../../src/app/modules/database/analysis-client-permission.ts';
+import type { IAnalysisRepository } from '../../../../../src/core/index.ts';
+
+type ClientPermissionRecord = {
+    id: string;
+    client_id: string;
+    permission_id?: string;
+    permission?: { name: string };
+};
+
+class FakeAuthupClient {
+    public createdClientPermissions: Record<string, any>[] = [];
+
+    public deletedClientPermissionIds: string[] = [];
+
+    private clientPermissions: ClientPermissionRecord[];
+
+    private permissions: Map<string, { id: string; name: string }>;
+
+    private seq = 0;
+
+    constructor(opts: {
+        permissions?: { id: string; name: string }[];
+        clientPermissions?: ClientPermissionRecord[];
+    } = {}) {
+        this.permissions = new Map((opts.permissions || []).map((p) => [p.id, p]));
+        this.clientPermissions = opts.clientPermissions || [];
+    }
+
+    clientPermission = {
+        getMany: async (query: { filter?: Record<string, any> } = {}) => {
+            let data = this.clientPermissions;
+            const filter = query.filter || {};
+            if (filter.client_id) {
+                data = data.filter((cp) => cp.client_id === filter.client_id);
+            }
+            if (filter.permission_id) {
+                data = data.filter((cp) => cp.permission_id === filter.permission_id);
+            }
+            return { data, meta: { total: data.length } };
+        },
+        create: async (data: Record<string, any>) => {
+            this.seq += 1;
+            const record = { id: `cp-${this.seq}`, ...data };
+            this.createdClientPermissions.push(data);
+            this.clientPermissions.push(record as ClientPermissionRecord);
+            return record;
+        },
+        delete: async (id: string) => {
+            this.deletedClientPermissionIds.push(id);
+            return { id };
+        },
+    };
+
+    permission = {
+        getOne: async (id: string) => {
+            const permission = this.permissions.get(id);
+            if (!permission) {
+                throw new Error(`permission ${id} not found`);
+            }
+            return permission;
+        },
+    };
+}
+
+function createAnalysisRepository(analyses: Partial<Analysis>[]): IAnalysisRepository {
+    return { findOneById: async (id: string) => analyses.find((a) => a.id === id) ?? null } as unknown as IAnalysisRepository;
+}
+
+function createAnalysis(overrides: Partial<Analysis> = {}): Partial<Analysis> {
+    return {
+        id: randomUUID(),
+        realm_id: randomUUID(),
+        client_id: 'client-1',
+        configuration_locked: false,
+        ...overrides,
+    };
+}
+
+const STORAGE_PERMISSION = { id: 'perm-storage', name: PermissionName.ANALYSIS_SELF_STORAGE_USE };
+const APPROVE_PERMISSION = { id: 'perm-approve', name: PermissionName.ANALYSIS_APPROVE };
+
+describe('AnalysisClientPermissionService', () => {
+    describe('getMany', () => {
+        it('should return the client permissions of the analysis client', async () => {
+            const analysis = createAnalysis({ client_id: 'client-1' });
+            const authup = new FakeAuthupClient({
+                clientPermissions: [
+                    {
+                        id: 'cp-1', 
+                        client_id: 'client-1', 
+                        permission: { name: STORAGE_PERMISSION.name }, 
+                    },
+                    {
+                        id: 'cp-2', 
+                        client_id: 'other', 
+                        permission: { name: STORAGE_PERMISSION.name }, 
+                    },
+                ],
+            });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            const { data } = await service.getMany(analysis.id!, createAllowAllActor());
+            expect(data).toHaveLength(1);
+            expect(data[0].id).toBe('cp-1');
+        });
+
+        it('should return empty when no client is provisioned', async () => {
+            const analysis = createAnalysis({ client_id: null });
+            const authup = new FakeAuthupClient();
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            const { data, meta } = await service.getMany(analysis.id!, createAllowAllActor());
+            expect(data).toHaveLength(0);
+            expect(meta.total).toBe(0);
+        });
+    });
+
+    describe('create', () => {
+        it('should grant a self-capability', async () => {
+            const analysis = createAnalysis({ client_id: 'client-1' });
+            const authup = new FakeAuthupClient({ permissions: [STORAGE_PERMISSION] });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await service.create(analysis.id!, { permission_id: STORAGE_PERMISSION.id }, createAllowAllActor());
+
+            expect(authup.createdClientPermissions).toHaveLength(1);
+            expect(authup.createdClientPermissions[0]).toMatchObject({
+                client_id: 'client-1',
+                permission_id: STORAGE_PERMISSION.id,
+            });
+        });
+
+        it('should reject a permission outside the analysis-self family', async () => {
+            const analysis = createAnalysis();
+            const authup = new FakeAuthupClient({ permissions: [APPROVE_PERMISSION] });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await expect(
+                service.create(analysis.id!, { permission_id: APPROVE_PERMISSION.id }, createAllowAllActor()),
+            ).rejects.toThrow(PermissionDeniedError);
+            expect(authup.createdClientPermissions).toHaveLength(0);
+        });
+
+        it('should reject when the analysis configuration is locked', async () => {
+            const analysis = createAnalysis({ configuration_locked: true });
+            const authup = new FakeAuthupClient({ permissions: [STORAGE_PERMISSION] });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await expect(
+                service.create(analysis.id!, { permission_id: STORAGE_PERMISSION.id }, createAllowAllActor()),
+            ).rejects.toThrow(BadRequestError);
+        });
+
+        it('should reject without a permission_id', async () => {
+            const analysis = createAnalysis();
+            const authup = new FakeAuthupClient();
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await expect(
+                service.create(analysis.id!, {}, createAllowAllActor()),
+            ).rejects.toThrow(BadRequestError);
+        });
+
+        it('should deny without permission', async () => {
+            const analysis = createAnalysis();
+            const authup = new FakeAuthupClient({ permissions: [STORAGE_PERMISSION] });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await expect(
+                service.create(analysis.id!, { permission_id: STORAGE_PERMISSION.id }, createDenyAllActor()),
+            ).rejects.toThrow();
+            expect(authup.createdClientPermissions).toHaveLength(0);
+        });
+
+        it('should 404 for an unknown analysis', async () => {
+            const authup = new FakeAuthupClient();
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([]),
+            });
+
+            await expect(
+                service.create(randomUUID(), { permission_id: STORAGE_PERMISSION.id }, createAllowAllActor()),
+            ).rejects.toThrow(EntityNotFoundError);
+        });
+    });
+
+    describe('delete', () => {
+        it('should remove the matching client permission', async () => {
+            const analysis = createAnalysis({ client_id: 'client-1' });
+            const authup = new FakeAuthupClient({
+                clientPermissions: [
+                    {
+                        id: 'cp-1', 
+                        client_id: 'client-1', 
+                        permission_id: STORAGE_PERMISSION.id, 
+                    },
+                ],
+            });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await service.delete(analysis.id!, STORAGE_PERMISSION.id, createAllowAllActor());
+            expect(authup.deletedClientPermissionIds).toEqual(['cp-1']);
+        });
+
+        it('should 404 when no matching client permission exists', async () => {
+            const analysis = createAnalysis({ client_id: 'client-1' });
+            const authup = new FakeAuthupClient({ clientPermissions: [] });
+            const service = new AnalysisClientPermissionService({
+                authup: authup as unknown as AuthupClient,
+                analysisRepository: createAnalysisRepository([analysis]),
+            });
+
+            await expect(
+                service.delete(analysis.id!, STORAGE_PERMISSION.id, createAllowAllActor()),
+            ).rejects.toThrow(EntityNotFoundError);
+        });
+    });
+});


### PR DESCRIPTION
## What

**Phase 2 of plan 010** — a guarded REST surface for managing which **self-capabilities** an analysis' dedicated Authup client holds. This is the configurability that the removed `AnalysisPermission` entity (#1692) implied, but done right: the analysis client itself is the source of truth, so there's **no new hub-side entity** — just a thin, guarded pass-through to Authup's `clientPermission` API.

Stacked on #1693 (Phase 1, which adds `analysis.client_id` + the `AnalysisClientService`). **Base this PR's review on the diff vs `feat/analysis-dedicated-client`.**

## Endpoints (`/analyses/:id/client/permissions`)

| Method | Purpose |
|--------|---------|
| `GET` | list the analysis client's capability assignments |
| `POST` `{ permission_id }` | grant a self-capability |
| `DELETE` `/:permissionId` | revoke a capability |

## Guarantees

- **Family constraint** — only `analysis_self_storage_use` / `analysis_self_message_broker_use` can be granted. An analysis client can never be handed a broad permission (e.g. `ANALYSIS_APPROVE`) through this surface.
- **Write gate** — `ANALYSIS_UPDATE` (global pre-check + attribute policy) **and** realm-writable, **and** rejected while the analysis configuration is locked.
- **Mounted only when Authup is available**, so the no-Authup paths (tests, local) are unaffected.

## Tests

`AnalysisClientPermissionService` unit tests (fake `AuthupClient` + fake repo + allow/deny actors): family constraint, lock guard, permission gating, missing `permission_id`, analysis-not-found, and grant/revoke. `nx test server-core` → **357** pass (+10).

## Deliberately deferred (fast-follow)

- **Security-tab UI** (client-vue component + client-ui page + `core-http-kit` client methods). The Nuxt app isn't runtime-verifiable in this environment, and the API is independently usable, so I'm shipping the verified backend first.

## Validation

- `nx build` (core-kit, server-core — incl. `tsc` decls + swagger gen) — green
- `nx test server-core` — 357 pass
- ESLint — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
