### PR TITLE
fix(server-core): derive project analysis count from rows to prevent negative values

### DIFF
--- a/apps/server-core/src/app/modules/database/repositories/analysis/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/analysis/repository.ts
@@ -138,6 +138,10 @@ export class AnalysisRepositoryAdapter implements IAnalysisRepository {
         return this.repository.findOne({ where: { id }, relations: ['project'] });
     }
 
+    async countByProject(projectId: string): Promise<number> {
+        return this.repository.countBy({ project_id: projectId });
+    }
+
     async findOneBy(where: Record<string, any>): Promise<Analysis | null> {
         return this.repository.findOneBy(where);
     }

--- a/apps/server-core/src/core/entities/analysis/service.ts
+++ b/apps/server-core/src/core/entities/analysis/service.ts
@@ -139,14 +139,19 @@ export class AnalysisService extends AbstractEntityService implements IAnalysisS
 
         await this.repository.save(entity, { data: actor.metadata });
 
+        // Derive the count from the actual rows instead of incrementing a stored
+        // counter — the latter drifts out of sync (e.g. when a later step below
+        // throws, or on concurrent creates) and can end up negative on delete.
+        // This runs before the steps that may throw so the count stays accurate
+        // even if the build/storage check fails after the analysis is persisted.
+        entity.project.analyses = await this.repository.countByProject(entity.project_id);
+        await this.projectRepository.save(entity.project, { data: actor.metadata });
+
         await this.assignProjectNodes(entity, actor);
 
         await this.recalculator.recalcDebounced(entity.id);
 
         await this.storageManager.check(entity);
-
-        entity.project.analyses++;
-        await this.projectRepository.save(entity.project, { data: actor.metadata });
 
         return entity;
     }
@@ -261,7 +266,9 @@ export class AnalysisService extends AbstractEntityService implements IAnalysisS
 
         entity.id = entityId;
 
-        project.analyses--;
+        // Recompute from the actual rows rather than decrementing a stored counter,
+        // which can drift below zero once it is out of sync.
+        project.analyses = await this.repository.countByProject(project.id);
         await this.projectRepository.save(project, { data: actor.metadata });
 
         entity.project = project;

--- a/apps/server-core/src/core/entities/analysis/types.ts
+++ b/apps/server-core/src/core/entities/analysis/types.ts
@@ -10,6 +10,7 @@ import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } 
 
 export interface IAnalysisRepository extends IEntityRepository<Analysis> {
     findOneWithProject(id: string): Promise<Analysis | null>;
+    countByProject(projectId: string): Promise<number>;
 }
 
 export interface IAnalysisMetadataRecalculator {

--- a/apps/server-core/test/unit/core/entities/analysis/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/analysis/fake-repository.ts
@@ -13,4 +13,8 @@ export class FakeAnalysisRepository extends FakeEntityRepository<Analysis> imple
     async findOneWithProject(id: string): Promise<Analysis | null> {
         return this.findOneById(id);
     }
+
+    async countByProject(projectId: string): Promise<number> {
+        return this.getAll().filter((entity) => entity.project_id === projectId).length;
+    }
 }

--- a/apps/server-core/test/unit/core/entities/analysis/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/analysis/service.spec.ts
@@ -212,6 +212,28 @@ describe('AnalysisService', () => {
             expect(analysisRecalculator.getDebouncedCalls()[0]).toBe(result.id);
         });
 
+        it('should recompute project.analyses from the actual rows on create', async () => {
+            // Stored counter starts out of sync (e.g. drifted negative); creating
+            // an analysis must resync it to the real row count, not blindly add one.
+            const project = createTestProject({ analyses: -3 });
+            projectRepository.seed(project);
+
+            const origValidate = analysisRepository.validateJoinColumns.bind(analysisRepository);
+            analysisRepository.validateJoinColumns = async (data: Partial<Analysis>) => {
+                await origValidate(data);
+                data.project = project;
+            };
+
+            const result = await service.create(
+                { name: 'test-analysis', project_id: project.id },
+                createAllowAllActor(),
+            );
+
+            const stored = await projectRepository.findOneById(project.id);
+            expect(result.project.analyses).toBe(1);
+            expect(stored?.analyses).toBe(1);
+        });
+
         it('should auto-generate a url-friendly name when none is provided', async () => {
             const project = createTestProject();
             projectRepository.seed(project);
@@ -448,17 +470,41 @@ describe('AnalysisService', () => {
             expect(remaining).toBeNull();
         });
 
-        it('should delete and decrement project.analyses', async () => {
+        it('should recompute project.analyses from the remaining rows on delete', async () => {
             const project = createTestProject();
-            project.analyses = 2;
+            // The stored counter is deliberately wrong to prove the value is
+            // recomputed from the actual rows, not merely decremented.
+            project.analyses = 5;
             projectRepository.seed(project);
-            analysisRepository.seed(createFullAnalysis({ project, project_id: project.id }));
+            analysisRepository.seed(createFullAnalysis({
+                id: 'analysis-1', 
+                project, 
+                project_id: project.id, 
+            }));
+            analysisRepository.seed(createFullAnalysis({
+                id: 'analysis-2', 
+                project, 
+                project_id: project.id, 
+            }));
 
-            expect(project.analyses).toBe(2);
             const result = await service.delete('analysis-1', createAllowAllActor());
 
             expect(result.id).toBe('analysis-1');
+            // one row remains for the project
             expect(result.project.analyses).toBe(1);
+        });
+
+        it('should never let project.analyses go negative when the counter is out of sync', async () => {
+            const project = createTestProject();
+            // Counter already drifted to 0 (or below) while a row still exists.
+            project.analyses = 0;
+            projectRepository.seed(project);
+            analysisRepository.seed(createFullAnalysis({ project, project_id: project.id }));
+
+            const result = await service.delete('analysis-1', createAllowAllActor());
+
+            expect(result.project.analyses).toBe(0);
+            expect(result.project.analyses).toBeGreaterThanOrEqual(0);
         });
 
         it('should throw PermissionDeniedError when actor lacks permission', async () => {


### PR DESCRIPTION
## Problem

Closes #1689 — a project was showing a **negative analysis count** in the UI (and it persisted across reloads, i.e. the value is wrong in the DB).

## Root cause

`projects.analyses` is a denormalized counter maintained via read-modify-write (`analyses++` on create, `analyses--` on delete). It drifts out of sync because:

- In `create`, the increment sat **after** `storageManager.check()`. If that step throws (e.g. a flaky storage service — plausible on staging), the analysis row is already persisted but the counter is never incremented.
- The `delete` decrement was **unconditional**, so once the counter is behind the real row count, deletes push it below zero.
- Concurrent creates lose updates the way any read-modify-write counter does.

Because the decrement is unconditional and the column is only `unsigned` at the DB layer (not enforced in JS before write), the value goes negative.

## Fix

Recompute `analyses` from the **actual analysis rows** on create and delete, via a new `IAnalysisRepository.countByProject()`:

- The value can never be negative (`COUNT(*) >= 0`).
- It is **self-healing**: any project whose counter has already drifted is corrected to the true value on its next create/delete.
- In `create`, the sync now runs **right after the row is persisted**, before the steps that may throw, so the count stays accurate even on partial failure.

## Notes

- No data-repair migration is included — the fix self-heals a project on its next create/delete. To clear an already-corrupted row immediately, run `UPDATE projects SET analyses = (SELECT COUNT(*) FROM analysis WHERE project_id = projects.id)`.
- The parallel `projects.nodes` counter (`ProjectNodeService`) has the identical read-modify-write pattern and the same latent negative-count risk; left out to keep this PR scoped to the reported issue — worth a follow-up.

## Testing

- Added unit tests: count recomputed from rows on create and delete, and never goes negative when the stored counter is already out of sync.
- `npx vitest run` (server-core): 385 passed.
- `tsc` and `eslint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analysis counters in projects now recalculate from actual database records during creation and deletion operations, improving overall data consistency.

* **Tests**
  * Added comprehensive test coverage for analysis counter synchronization behavior, including handling of out-of-sync states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->