### PR TITLE
feat(server-core): node registry credentials read route

### DIFF
--- a/apps/client-ui/pages/admin/nodes/[id]/registry.vue
+++ b/apps/client-ui/pages/admin/nodes/[id]/registry.vue
@@ -7,11 +7,11 @@
 <script lang="ts">
 import type { Node } from '@privateaim/core-kit';
 import type { PropType } from 'vue';
-import { FNodeRegistryProject } from '@privateaim/client-vue';
+import { FNodeRegistryCredentials, FNodeRegistryProject } from '@privateaim/client-vue';
 import { defineNuxtComponent } from '#app';
 
 export default defineNuxtComponent({
-    components: { FNodeRegistryProject },
+    components: { FNodeRegistryCredentials, FNodeRegistryProject },
     props: {
         entity: {
             type: Object as PropType<Node>,
@@ -36,11 +36,22 @@ export default defineNuxtComponent({
 });
 </script>
 <template>
-    <FNodeRegistryProject
+    <div
         v-if="entity"
-        :entity="entity"
-        :realm-id="entity.realm_id"
-        @updated="handleUpdated"
-        @failed="handleFailed"
-    />
+        class="flex flex-col gap-4"
+    >
+        <FNodeRegistryCredentials
+            :entity="entity"
+            @failed="handleFailed"
+        />
+
+        <hr class="my-0">
+
+        <FNodeRegistryProject
+            :entity="entity"
+            :realm-id="entity.realm_id"
+            @updated="handleUpdated"
+            @failed="handleFailed"
+        />
+    </div>
 </template>

--- a/apps/server-core/src/adapters/http/controllers/entities/node-client-credential/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/node-client-credential/module.ts
@@ -18,6 +18,7 @@ import type { IAppEvent } from 'routup';
 import { ForceLoggedInMiddleware } from '@privateaim/server-http-kit';
 import type {
     ClientCredentials,
+    ClientCredentialsUpdate,
     INodeClientCredentialService,
 } from '../../../../../core/services/client-credential/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -47,10 +48,10 @@ export class NodeClientCredentialController {
     @DPost('/:id/client/credentials', [ForceLoggedInMiddleware])
     async setCredentials(
         @DPath('id') id: string,
-        @DBody() data: { secret?: string },
+        @DBody() data: ClientCredentialsUpdate,
         @DContext() event: IAppEvent,
     ): Promise<ClientCredentials> {
         const actor = buildActorContext(event);
-        return this.service.setCredentials(id, data?.secret, actor);
+        return this.service.setCredentials(id, data ?? {}, actor);
     }
 }

--- a/apps/server-core/src/adapters/http/controllers/entities/node-registry-credential/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/node-registry-credential/module.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    DContext,
+    DController,
+    DGet,
+    DPath,
+    DTags,
+} from '@routup/decorators';
+import type { IAppEvent } from 'routup';
+import { ForceLoggedInMiddleware } from '@privateaim/server-http-kit';
+import type {
+    INodeRegistryCredentialService,
+    RegistryCredentials,
+} from '../../../../../core/services/registry-credential/index.ts';
+import { buildActorContext } from '../../../request/index.ts';
+
+type NodeRegistryCredentialControllerContext = {
+    service: INodeRegistryCredentialService;
+};
+
+@DTags('node')
+@DController('/nodes')
+export class NodeRegistryCredentialController {
+    protected service: INodeRegistryCredentialService;
+
+    constructor(ctx: NodeRegistryCredentialControllerContext) {
+        this.service = ctx.service;
+    }
+
+    @DGet('/:id/registry/credentials', [ForceLoggedInMiddleware])
+    async getCredentials(
+        @DPath('id') id: string,
+        @DContext() event: IAppEvent,
+    ): Promise<RegistryCredentials> {
+        const actor = buildActorContext(event);
+        return this.service.getCredentials(id, actor);
+    }
+}

--- a/apps/server-core/src/app/modules/database/authup-client-credential-store.ts
+++ b/apps/server-core/src/app/modules/database/authup-client-credential-store.ts
@@ -7,7 +7,11 @@
 
 import { randomBytes } from 'node:crypto';
 import type { AuthupClient } from '@privateaim/server-kit';
-import type { ClientCredentials, IClientCredentialStore } from '../../../core/services/client-credential/index.ts';
+import type {
+    ClientCredentials,
+    ClientCredentialsUpdate,
+    IClientCredentialStore,
+} from '../../../core/services/client-credential/index.ts';
 
 /**
  * Authup-backed adapter for the {@link IClientCredentialStore} core port. Reads
@@ -26,19 +30,25 @@ export class AuthupClientCredentialStore implements IClientCredentialStore {
 
         return {
             id: client.id,
+            name: client.name,
+            display_name: client.display_name ?? null,
             secret: client.secret ?? null,
         };
     }
 
-    async writeByClientId(clientId: string, secret?: string): Promise<ClientCredentials> {
+    async writeByClientId(clientId: string, data?: ClientCredentialsUpdate): Promise<ClientCredentials> {
         // Rotate by default (generate a fresh secret); otherwise set the caller's.
-        const next = secret ?? randomBytes(32).toString('hex');
+        // Undefined name/display_name keys are dropped on the wire, leaving them
+        // unchanged.
+        const next = data?.secret ?? randomBytes(32).toString('hex');
 
-        const client = await this.authup.client.update(clientId, { secret: next });
+        const client = await this.authup.client.update(clientId, { ...data, secret: next });
 
         // Return the plaintext we wrote — the stored value may be hashed.
         return {
             id: client.id,
+            name: client.name,
+            display_name: client.display_name ?? null,
             secret: next,
         };
     }

--- a/apps/server-core/src/app/modules/database/repositories/registry-project/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/registry-project/repository.ts
@@ -113,6 +113,14 @@ export class RegistryProjectRepositoryAdapter implements IRegistryProjectReposit
         return this.repository.findOneBy({ id });
     }
 
+    async findOneWithSecret(id: string): Promise<RegistryProject | null> {
+        const qb = this.repository.createQueryBuilder('registryProject')
+            .addSelect(['registryProject.account_secret'])
+            .where('registryProject.id = :id', { id });
+
+        return qb.getOne();
+    }
+
     async findOneBy(where: Record<string, any>): Promise<RegistryProject | null> {
         return this.repository.findOneBy(where);
     }

--- a/apps/server-core/src/app/modules/http/controller.ts
+++ b/apps/server-core/src/app/modules/http/controller.ts
@@ -41,10 +41,12 @@ import { AnalysisClientPermissionController } from '../../../adapters/http/contr
 import { AnalysisClientPermissionService } from '../database/analysis-client-permission.ts';
 import { AnalysisClientCredentialController } from '../../../adapters/http/controllers/entities/analysis-client-credential/module.ts';
 import { NodeClientCredentialController } from '../../../adapters/http/controllers/entities/node-client-credential/module.ts';
+import { NodeRegistryCredentialController } from '../../../adapters/http/controllers/entities/node-registry-credential/module.ts';
 import {
     AnalysisClientCredentialService,
     NodeClientCredentialService,
 } from '../../../core/services/client-credential/index.ts';
+import { NodeRegistryCredentialService } from '../../../core/services/registry-credential/index.ts';
 import { AuthupClientCredentialStore } from '../database/authup-client-credential-store.ts';
 import { ServiceController } from '../../../adapters/http/controllers/workflows/service/index.ts';
 import { DatabaseInjectionKey } from '../database/constants.ts';
@@ -126,10 +128,16 @@ export function createControllers(container: IContainer): Record<string, any>[] 
         skipAnalysisApproval: config.skipAnalysisApproval,
     });
     const analysisNodeEventService = new AnalysisNodeEventService({ repository: analysisNodeEventRepository });
+    const nodeRegistryCredentialService = new NodeRegistryCredentialService({
+        repository: nodeRepository,
+        registryRepository,
+        registryProjectRepository,
+    });
 
     // Create controller instances
     const controllers: Record<string, any>[] = [
         new NodeController({ service: nodeService }),
+        new NodeRegistryCredentialController({ service: nodeRegistryCredentialService }),
         new RegistryController({ service: registryService }),
         new MasterImageController({ service: masterImageService }),
         new MasterImageGroupController({ service: masterImageGroupService }),

--- a/apps/server-core/src/core/entities/registry-project/types.ts
+++ b/apps/server-core/src/core/entities/registry-project/types.ts
@@ -8,7 +8,9 @@
 import type { RegistryProject } from '@privateaim/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } from '@privateaim/server-kit';
 
-export interface IRegistryProjectRepository extends IEntityRepository<RegistryProject> {}
+export interface IRegistryProjectRepository extends IEntityRepository<RegistryProject> {
+    findOneWithSecret(id: string): Promise<RegistryProject | null>;
+}
 
 export interface IRegistryProjectService {
     getMany(query: Record<string, any>, actor: ActorContext): Promise<EntityRepositoryFindManyResult<RegistryProject>>;

--- a/apps/server-core/src/core/services/client-credential/analysis.ts
+++ b/apps/server-core/src/core/services/client-credential/analysis.ts
@@ -99,7 +99,7 @@ export class AnalysisClientCredentialService extends AbstractEntityService imple
             throw new BadRequestError('The analysis has no client provisioned yet.');
         }
 
-        return this.credentialStore.writeByClientId(analysis.client_id, secret);
+        return this.credentialStore.writeByClientId(analysis.client_id, { secret });
     }
 
     /**

--- a/apps/server-core/src/core/services/client-credential/analysis.ts
+++ b/apps/server-core/src/core/services/client-credential/analysis.ts
@@ -103,29 +103,32 @@ export class AnalysisClientCredentialService extends AbstractEntityService imple
     }
 
     /**
-     * Fail-closed: a master-realm member (admin/ops) may always read; otherwise
-     * the actor must be the client of a node that is assigned to this analysis
-     * with an APPROVED analysis-node link. Everything else is denied.
+     * Fail-closed: the client of a node that is assigned to this analysis with
+     * an APPROVED analysis-node link may always read (the referenced identity);
+     * any other caller must actually hold {@link PermissionName.ANALYSIS_UPDATE}.
+     * Being a master-realm member is, by itself, not sufficient: membership is
+     * not a permission.
      */
     protected async isAuthorized(analysis: Analysis, actor: ActorContext): Promise<boolean> {
-        if (this.isActorMasterRealmMember(actor)) {
+        if (actor.identity && actor.identity.type === 'client') {
+            const node = await this.nodeRepository.findOneBy({ client_id: actor.identity.id });
+            if (node) {
+                const analysisNode = await this.analysisNodeRepository.findOneBy({
+                    analysis_id: analysis.id,
+                    node_id: node.id,
+                });
+
+                if (analysisNode && analysisNode.approval_status === AnalysisNodeApprovalStatus.APPROVED) {
+                    return true;
+                }
+            }
+        }
+
+        try {
+            await actor.permissionChecker.preCheck({ name: PermissionName.ANALYSIS_UPDATE });
             return true;
-        }
-
-        if (!actor.identity || actor.identity.type !== 'client') {
+        } catch {
             return false;
         }
-
-        const node = await this.nodeRepository.findOneBy({ client_id: actor.identity.id });
-        if (!node) {
-            return false;
-        }
-
-        const analysisNode = await this.analysisNodeRepository.findOneBy({
-            analysis_id: analysis.id,
-            node_id: node.id,
-        });
-
-        return !!analysisNode && analysisNode.approval_status === AnalysisNodeApprovalStatus.APPROVED;
     }
 }

--- a/apps/server-core/src/core/services/client-credential/node.ts
+++ b/apps/server-core/src/core/services/client-credential/node.ts
@@ -12,6 +12,7 @@ import type { ActorContext } from '@privateaim/server-kit';
 import type { INodeRepository } from '../../entities/node/types.ts';
 import type {
     ClientCredentials,
+    ClientCredentialsUpdate,
     IClientCredentialStore,
     INodeClientCredentialService,
 } from './types.ts';
@@ -59,7 +60,7 @@ export class NodeClientCredentialService implements INodeClientCredentialService
 
     async setCredentials(
         nodeId: string,
-        secret: string | undefined,
+        data: ClientCredentialsUpdate,
         actor: ActorContext,
     ): Promise<ClientCredentials> {
         const node = await this.repository.findOneById(nodeId);
@@ -75,7 +76,7 @@ export class NodeClientCredentialService implements INodeClientCredentialService
             throw new BadRequestError('The node has no client provisioned yet.');
         }
 
-        return this.credentialStore.writeByClientId(node.client_id, secret);
+        return this.credentialStore.writeByClientId(node.client_id, data);
     }
 
     /**

--- a/apps/server-core/src/core/services/client-credential/node.ts
+++ b/apps/server-core/src/core/services/client-credential/node.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Node } from '@privateaim/core-kit';
 import { PermissionName, isRealmResourceWritable } from '@privateaim/kit';
 import { BadRequestError, EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
 import type { ActorContext } from '@privateaim/server-kit';
@@ -22,9 +23,10 @@ type NodeClientCredentialServiceContext = {
 
 /**
  * Hands the credentials of a node's dedicated client to the parties allowed to
- * manage the node, mirroring the analysis client credential pull path.
- * Fail-closed: the actor must hold NODE_UPDATE and be permitted to write the
- * node's realm (which a master-realm member always is).
+ * manage the node. Fail-closed: the node's own client may always manage its own
+ * credentials (the referenced identity); any other caller must hold NODE_UPDATE
+ * and be permitted to write the node's realm (which a master-realm member always
+ * is).
  */
 export class NodeClientCredentialService implements INodeClientCredentialService {
     protected repository: INodeRepository;
@@ -37,16 +39,14 @@ export class NodeClientCredentialService implements INodeClientCredentialService
     }
 
     async getCredentials(nodeId: string, actor: ActorContext): Promise<ClientCredentials> {
-        // Authorize before touching node state, so an unauthorized caller can
-        // never infer provisioning state from BadRequest vs PermissionDenied.
-        await actor.permissionChecker.preCheck({ name: PermissionName.NODE_UPDATE });
-
         const node = await this.repository.findOneById(nodeId);
         if (!node) {
             throw new EntityNotFoundError({ entity: 'node' });
         }
 
-        if (!isRealmResourceWritable(actor.realm, node.realm_id)) {
+        // Authorize before exposing provisioning state, so an unauthorized
+        // caller can never infer it from BadRequest vs PermissionDenied.
+        if (!(await this.isAuthorized(node, actor))) {
             throw new PermissionDeniedError('You are not permitted to read the credentials of this node client.');
         }
 
@@ -62,15 +62,12 @@ export class NodeClientCredentialService implements INodeClientCredentialService
         secret: string | undefined,
         actor: ActorContext,
     ): Promise<ClientCredentials> {
-        // Same management gate as the read path; the running node never rotates.
-        await actor.permissionChecker.preCheck({ name: PermissionName.NODE_UPDATE });
-
         const node = await this.repository.findOneById(nodeId);
         if (!node) {
             throw new EntityNotFoundError({ entity: 'node' });
         }
 
-        if (!isRealmResourceWritable(actor.realm, node.realm_id)) {
+        if (!(await this.isAuthorized(node, actor))) {
             throw new PermissionDeniedError('You are not permitted to write the credentials of this node client.');
         }
 
@@ -79,5 +76,30 @@ export class NodeClientCredentialService implements INodeClientCredentialService
         }
 
         return this.credentialStore.writeByClientId(node.client_id, secret);
+    }
+
+    /**
+     * Fail-closed: the node's own client may always manage its own credentials
+     * (the referenced identity); any other caller must actually hold NODE_UPDATE
+     * and be permitted to write the node's realm. Being a master-realm member
+     * is, by itself, not sufficient: membership is not a permission.
+     */
+    private async isAuthorized(node: Node, actor: ActorContext): Promise<boolean> {
+        if (
+            actor.identity &&
+            actor.identity.type === 'client' &&
+            !!node.client_id &&
+            node.client_id === actor.identity.id
+        ) {
+            return true;
+        }
+
+        try {
+            await actor.permissionChecker.preCheck({ name: PermissionName.NODE_UPDATE });
+        } catch {
+            return false;
+        }
+
+        return isRealmResourceWritable(actor.realm, node.realm_id);
     }
 }

--- a/apps/server-core/src/core/services/client-credential/types.ts
+++ b/apps/server-core/src/core/services/client-credential/types.ts
@@ -5,31 +5,41 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Client } from '@authup/core-kit';
 import type { ActorContext } from '@privateaim/server-kit';
 
-export type ClientCredentials = {
-    id: string;
-    secret: string | null;
-};
+/**
+ * The subset of an OAuth2 client a credential consumer needs — identity, the
+ * human-facing labels and the secret. Projected from the Authup {@link Client}.
+ */
+export type ClientCredentials = Pick<Client, 'id' | 'name' | 'display_name' | 'secret'>;
 
 /**
- * Port for reading and writing an OAuth2 client's credentials (id + secret) by
- * its id. The concrete, Authup-backed adapter lives in the app layer, keeping
- * the credential services free of any infrastructure client.
+ * Patch applied to an OAuth2 client's credentials. An omitted `secret` rotates
+ * to a fresh random one; an omitted `name` / `display_name` leaves that field
+ * unchanged. Projected from the Authup {@link Client}.
+ */
+export type ClientCredentialsUpdate = Partial<Pick<Client, 'secret' | 'name' | 'display_name'>>;
+
+/**
+ * Port for reading and writing an OAuth2 client's credentials (id, name,
+ * secret) by its id. The concrete, Authup-backed adapter lives in the app
+ * layer, keeping the credential services free of any infrastructure client.
  */
 export interface IClientCredentialStore {
     readByClientId(clientId: string): Promise<ClientCredentials>;
 
     /**
-     * Set the client's secret. When `secret` is omitted, a new random secret is
-     * generated. Returns the (plaintext) credentials that were written.
+     * Apply a credentials patch. When `secret` is omitted, a new random secret
+     * is generated; when `name` is omitted, the name is left unchanged. Returns
+     * the (plaintext) credentials that were written.
      */
-    writeByClientId(clientId: string, secret?: string): Promise<ClientCredentials>;
+    writeByClientId(clientId: string, data?: ClientCredentialsUpdate): Promise<ClientCredentials>;
 }
 
 export interface INodeClientCredentialService {
     getCredentials(nodeId: string, actor: ActorContext): Promise<ClientCredentials>;
-    setCredentials(nodeId: string, secret: string | undefined, actor: ActorContext): Promise<ClientCredentials>;
+    setCredentials(nodeId: string, data: ClientCredentialsUpdate, actor: ActorContext): Promise<ClientCredentials>;
 }
 
 export interface IAnalysisClientCredentialService {

--- a/apps/server-core/src/core/services/registry-credential/index.ts
+++ b/apps/server-core/src/core/services/registry-credential/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './types.ts';
+export * from './node.ts';

--- a/apps/server-core/src/core/services/registry-credential/node.ts
+++ b/apps/server-core/src/core/services/registry-credential/node.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Node } from '@privateaim/core-kit';
+import { PermissionName } from '@privateaim/kit';
+import { BadRequestError, EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
+import type { ActorContext } from '@privateaim/server-kit';
+import { AbstractEntityService } from '@privateaim/server-kit';
+import type { INodeRepository } from '../../entities/node/types.ts';
+import type { IRegistryRepository } from '../../entities/registry/types.ts';
+import type { IRegistryProjectRepository } from '../../entities/registry-project/types.ts';
+import type { INodeRegistryCredentialService, RegistryCredentials } from './types.ts';
+
+type NodeRegistryCredentialServiceContext = {
+    repository: INodeRepository;
+    registryRepository: IRegistryRepository;
+    registryProjectRepository: IRegistryProjectRepository;
+};
+
+/**
+ * Hands a node the credentials of its own registry project (Harbor robot
+ * account) so it can pull/push images without holding any management
+ * permission. Fail-closed: only a master-realm member or the node's own client
+ * may read the secret — everything else is denied.
+ */
+export class NodeRegistryCredentialService extends AbstractEntityService implements INodeRegistryCredentialService {
+    protected repository: INodeRepository;
+
+    protected registryRepository: IRegistryRepository;
+
+    protected registryProjectRepository: IRegistryProjectRepository;
+
+    constructor(ctx: NodeRegistryCredentialServiceContext) {
+        super();
+        this.repository = ctx.repository;
+        this.registryRepository = ctx.registryRepository;
+        this.registryProjectRepository = ctx.registryProjectRepository;
+    }
+
+    async getCredentials(nodeId: string, actor: ActorContext): Promise<RegistryCredentials> {
+        const node = await this.repository.findOneById(nodeId);
+        if (!node) {
+            throw new EntityNotFoundError({ entity: 'node' });
+        }
+
+        // Authorize before exposing provisioning state, so an unauthorized
+        // caller can never infer it from BadRequest vs PermissionDenied.
+        if (!(await this.isAuthorized(node, actor))) {
+            throw new PermissionDeniedError('You are not permitted to read the registry credentials of this node.');
+        }
+
+        if (!node.registry_project_id) {
+            throw new BadRequestError('The node has no registry project provisioned yet.');
+        }
+
+        const registryProject = await this.registryProjectRepository.findOneWithSecret(node.registry_project_id);
+        if (!registryProject) {
+            throw new BadRequestError('The registry project of the node could not be found.');
+        }
+
+        const registry = await this.registryRepository.findOneById(registryProject.registry_id);
+        if (!registry) {
+            throw new BadRequestError('The registry of the node could not be found.');
+        }
+
+        return {
+            host: registry.host,
+            external_name: registryProject.external_name,
+            account_name: registryProject.account_name,
+            account_secret: registryProject.account_secret,
+        };
+    }
+
+    /**
+     * Fail-closed: the node's own client may always read its own credentials
+     * (the referenced identity); any other caller must actually hold
+     * {@link PermissionName.REGISTRY_MANAGE} — the same permission that gates
+     * this secret on the registry-project endpoint. Being a master-realm member
+     * is, by itself, not sufficient: membership is not a permission.
+     */
+    protected async isAuthorized(node: Node, actor: ActorContext): Promise<boolean> {
+        if (
+            actor.identity &&
+            actor.identity.type === 'client' &&
+            !!node.client_id &&
+            node.client_id === actor.identity.id
+        ) {
+            return true;
+        }
+
+        try {
+            await actor.permissionChecker.preCheck({ name: PermissionName.REGISTRY_MANAGE });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/apps/server-core/src/core/services/registry-credential/types.ts
+++ b/apps/server-core/src/core/services/registry-credential/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Registry, RegistryProject } from '@privateaim/core-kit';
+import type { ActorContext } from '@privateaim/server-kit';
+
+/**
+ * The registry coordinates a node needs to authenticate against its own
+ * docker registry project (Harbor robot account): the registry host plus
+ * account credentials, projected from {@link Registry}, and the project
+ * namespace (`external_name`), which only lives on {@link RegistryProject}.
+ */
+export type RegistryCredentials =    & Pick<Registry, 'host' | 'account_name' | 'account_secret'> &
+    Pick<RegistryProject, 'external_name'>;
+
+export interface INodeRegistryCredentialService {
+    getCredentials(nodeId: string, actor: ActorContext): Promise<RegistryCredentials>;
+}

--- a/apps/server-core/test/unit/app/modules/database/authup-client-credential-store.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/authup-client-credential-store.spec.ts
@@ -10,13 +10,18 @@ import { describe, expect, it } from 'vitest';
 import { AuthupClientCredentialStore } from '../../../../../src/app/modules/database/authup-client-credential-store.ts';
 
 describe('AuthupClientCredentialStore', () => {
-    it('should fetch the client with the +secret field and map id/secret', async () => {
+    it('should fetch the client with the +secret field and map id/name/display_name/secret', async () => {
         const calls: { id: string; options?: any }[] = [];
         const authup = {
             client: {
                 getOne: async (id: string, options?: any) => {
                     calls.push({ id, options });
-                    return { id, secret: 'sek' };
+                    return {
+                        id, 
+                        name: 'node-1', 
+                        display_name: 'Node 1', 
+                        secret: 'sek', 
+                    };
                 },
             },
         };
@@ -24,17 +29,35 @@ describe('AuthupClientCredentialStore', () => {
         const reader = new AuthupClientCredentialStore(authup as unknown as AuthupClient);
         const result = await reader.readByClientId('client-1');
 
-        expect(result).toEqual({ id: 'client-1', secret: 'sek' });
+        expect(result).toEqual({
+            id: 'client-1',
+            name: 'node-1',
+            display_name: 'Node 1',
+            secret: 'sek',
+        });
         expect(calls[0]).toEqual({ id: 'client-1', options: { fields: ['+secret'] } });
     });
 
-    it('should null a missing secret', async () => {
-        const authup = { client: { getOne: async (id: string) => ({ id, secret: undefined }) } };
+    it('should null a missing secret and display_name', async () => {
+        const authup = {
+            client: {
+                getOne: async (id: string) => ({
+                    id, 
+                    name: 'node-2', 
+                    secret: undefined, 
+                }), 
+            }, 
+        };
 
         const reader = new AuthupClientCredentialStore(authup as unknown as AuthupClient);
         const result = await reader.readByClientId('client-2');
 
-        expect(result).toEqual({ id: 'client-2', secret: null });
+        expect(result).toEqual({
+            id: 'client-2',
+            name: 'node-2',
+            display_name: null,
+            secret: null,
+        });
     });
 
     it('should set a provided secret via client update and return the plaintext', async () => {
@@ -43,17 +66,27 @@ describe('AuthupClientCredentialStore', () => {
             client: {
                 update: async (id: string, data?: any) => {
                     calls.push({ id, data });
-                    return { id, secret: 'stored-hash' };
+                    return {
+                        id, 
+                        name: 'node-1', 
+                        display_name: null, 
+                        secret: 'stored-hash', 
+                    };
                 },
             },
         };
 
         const store = new AuthupClientCredentialStore(authup as unknown as AuthupClient);
-        const result = await store.writeByClientId('client-1', 'my-secret');
+        const result = await store.writeByClientId('client-1', { secret: 'my-secret' });
 
         expect(calls[0]).toEqual({ id: 'client-1', data: { secret: 'my-secret' } });
         // Returns what we wrote, not the (possibly hashed) stored value.
-        expect(result).toEqual({ id: 'client-1', secret: 'my-secret' });
+        expect(result).toEqual({
+            id: 'client-1',
+            name: 'node-1',
+            display_name: null,
+            secret: 'my-secret',
+        });
     });
 
     it('should generate a secret when none is provided and write+return it', async () => {
@@ -62,7 +95,12 @@ describe('AuthupClientCredentialStore', () => {
             client: {
                 update: async (id: string, data?: any) => {
                     calls.push({ id, data });
-                    return { id, secret: 'stored-hash' };
+                    return {
+                        id, 
+                        name: 'node-2', 
+                        display_name: null, 
+                        secret: 'stored-hash', 
+                    };
                 },
             },
         };
@@ -73,6 +111,37 @@ describe('AuthupClientCredentialStore', () => {
         const written = calls[0].data.secret;
         expect(typeof written).toBe('string');
         expect(written.length).toBeGreaterThan(0);
-        expect(result).toEqual({ id: 'client-2', secret: written });
+        expect(result).toEqual({
+            id: 'client-2',
+            name: 'node-2',
+            display_name: null,
+            secret: written,
+        });
+    });
+
+    it('should pass name and display_name through to the client update', async () => {
+        const calls: { id: string; data?: any }[] = [];
+        const authup = {
+            client: {
+                update: async (id: string, data?: any) => {
+                    calls.push({ id, data });
+                    return {
+                        id, 
+                        name: data.name, 
+                        display_name: data.display_name ?? null, 
+                        secret: data.secret, 
+                    };
+                },
+            },
+        };
+
+        const store = new AuthupClientCredentialStore(authup as unknown as AuthupClient);
+        await store.writeByClientId('client-3', { name: 'renamed', display_name: 'Renamed' });
+
+        // An omitted secret still rotates; the labels ride along on the update.
+        expect(calls[0].data.name).toBe('renamed');
+        expect(calls[0].data.display_name).toBe('Renamed');
+        expect(typeof calls[0].data.secret).toBe('string');
+        expect(calls[0].data.secret.length).toBeGreaterThan(0);
     });
 });

--- a/apps/server-core/test/unit/core/entities/registry-project/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/registry-project/fake-repository.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { RegistryProject } from '@privateaim/core-kit';
+import type { IRegistryProjectRepository } from '../../../../../src/core/entities/registry-project/types.ts';
+import { FakeEntityRepository } from '@privateaim/server-test-kit';
+
+export class FakeRegistryProjectRepository extends FakeEntityRepository<RegistryProject> implements IRegistryProjectRepository {
+    async findOneWithSecret(id: string): Promise<RegistryProject | null> {
+        return this.findOneById(id);
+    }
+}

--- a/apps/server-core/test/unit/core/entities/registry-project/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/registry-project/service.spec.ts
@@ -25,9 +25,10 @@ import {
     createNonMasterRealmActor,
 } from '../../helpers/index.ts';
 import { FakeRegistryManager } from '../node/fake-registry-manager.ts';
+import { FakeRegistryProjectRepository } from './fake-repository.ts';
 
 function createFakeRegistryProjectRepository() {
-    const repo = new FakeEntityRepository<RegistryProject>();
+    const repo = new FakeRegistryProjectRepository();
 
     const originalValidateJoinColumns = repo.validateJoinColumns.bind(repo);
     repo.validateJoinColumns = async (data: Partial<RegistryProject>) => {

--- a/apps/server-core/test/unit/core/services/client-credential/analysis.spec.ts
+++ b/apps/server-core/test/unit/core/services/client-credential/analysis.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { REALM_MASTER_NAME } from '@authup/core-kit';
 import type { Analysis, AnalysisNode, Node } from '@privateaim/core-kit';
 import { AnalysisNodeApprovalStatus } from '@privateaim/core-kit';
 import { BadRequestError, EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
@@ -50,7 +51,24 @@ function nodeClientActor(clientId: string): ActorContext {
 }
 
 function userActor(): ActorContext {
-    return { realm: { name: 'some-realm' }, identity: { type: 'user', id: randomUUID() } } as unknown as ActorContext;
+    return {
+        realm: { name: 'some-realm' },
+        identity: { type: 'user', id: randomUUID() },
+        // A plain user without ANALYSIS_UPDATE.
+        permissionChecker: { preCheck: async () => { throw new Error('forbidden'); } },
+    } as unknown as ActorContext;
+}
+
+/**
+ * A master-realm member who does NOT hold ANALYSIS_UPDATE — used to prove that
+ * realm membership alone never grants access.
+ */
+function masterRealmWithoutPermissionActor(): ActorContext {
+    return {
+        realm: { name: REALM_MASTER_NAME },
+        identity: { type: 'user', id: randomUUID() },
+        permissionChecker: { preCheck: async () => { throw new Error('forbidden'); } },
+    } as unknown as ActorContext;
 }
 
 const ANALYSIS_ID = randomUUID();
@@ -82,13 +100,24 @@ function baseAnalysis(overrides: Partial<Analysis> = {}): Partial<Analysis> {
 }
 
 describe('AnalysisClientCredentialService', () => {
-    it('should return credentials for a master-realm member', async () => {
+    it('should return credentials for a permitted manager', async () => {
         const { service, reader } = buildService({ analysis: baseAnalysis() });
 
         const credentials = await service.getCredentials(ANALYSIS_ID, createAllowAllActor());
 
         expect(credentials).toEqual({ id: 'analysis-client-1', secret: 'the-secret' });
         expect(reader.calls).toEqual(['analysis-client-1']);
+    });
+
+    it('should deny a master-realm member that lacks the permission', async () => {
+        // Realm membership is not a permission: without ANALYSIS_UPDATE, even a
+        // master-realm member must be denied.
+        const { service, reader } = buildService({ analysis: baseAnalysis() });
+
+        await expect(
+            service.getCredentials(ANALYSIS_ID, masterRealmWithoutPermissionActor()),
+        ).rejects.toThrow(PermissionDeniedError);
+        expect(reader.calls).toHaveLength(0);
     });
 
     it('should return credentials for the client of an approved, assigned node', async () => {

--- a/apps/server-core/test/unit/core/services/client-credential/analysis.spec.ts
+++ b/apps/server-core/test/unit/core/services/client-credential/analysis.spec.ts
@@ -105,7 +105,12 @@ describe('AnalysisClientCredentialService', () => {
 
         const credentials = await service.getCredentials(ANALYSIS_ID, createAllowAllActor());
 
-        expect(credentials).toEqual({ id: 'analysis-client-1', secret: 'the-secret' });
+        expect(credentials).toEqual({
+            id: 'analysis-client-1',
+            name: 'the-name',
+            display_name: null,
+            secret: 'the-secret',
+        });
         expect(reader.calls).toEqual(['analysis-client-1']);
     });
 
@@ -199,7 +204,7 @@ describe('AnalysisClientCredentialService', () => {
 
             const credentials = await service.setCredentials(ANALYSIS_ID, undefined, createAllowAllActor());
 
-            expect(reader.writes).toEqual([{ clientId: 'analysis-client-1', secret: undefined }]);
+            expect(reader.writes).toEqual([{ clientId: 'analysis-client-1', data: { secret: undefined } }]);
             expect(credentials.secret).toBe('generated-secret');
         });
 

--- a/apps/server-core/test/unit/core/services/client-credential/fake-credential-store.ts
+++ b/apps/server-core/test/unit/core/services/client-credential/fake-credential-store.ts
@@ -7,28 +7,39 @@
 
 import type {
     ClientCredentials,
+    ClientCredentialsUpdate,
     IClientCredentialStore,
 } from '../../../../../src/core/services/client-credential/index.ts';
 
 /**
  * In-memory {@link IClientCredentialStore} that records the client ids it was
- * asked for and returns a fixed secret. Lets the credential service tests assert
- * authorization without touching Authup.
+ * asked for and the patches it was given, returning a fixed secret/name. Lets
+ * the credential service tests assert authorization without touching Authup.
  */
 export class FakeClientCredentialStore implements IClientCredentialStore {
     public calls: string[] = [];
 
-    public writes: { clientId: string; secret?: string }[] = [];
+    public writes: { clientId: string; data?: ClientCredentialsUpdate }[] = [];
 
-    constructor(private secret: string | null = 'the-secret') {}
+    constructor(private secret: string | null = 'the-secret', private name: string | null = 'the-name') {}
 
     async readByClientId(clientId: string): Promise<ClientCredentials> {
         this.calls.push(clientId);
-        return { id: clientId, secret: this.secret };
+        return {
+            id: clientId,
+            name: this.name,
+            display_name: null,
+            secret: this.secret,
+        };
     }
 
-    async writeByClientId(clientId: string, secret?: string): Promise<ClientCredentials> {
-        this.writes.push({ clientId, secret });
-        return { id: clientId, secret: secret ?? 'generated-secret' };
+    async writeByClientId(clientId: string, data?: ClientCredentialsUpdate): Promise<ClientCredentials> {
+        this.writes.push({ clientId, data });
+        return {
+            id: clientId,
+            name: data?.name ?? this.name,
+            display_name: data?.display_name ?? null,
+            secret: data?.secret ?? 'generated-secret',
+        };
     }
 }

--- a/apps/server-core/test/unit/core/services/client-credential/node.spec.ts
+++ b/apps/server-core/test/unit/core/services/client-credential/node.spec.ts
@@ -31,6 +31,18 @@ function realmManagerActor(realmId: string): ActorContext {
     } as unknown as ActorContext;
 }
 
+/**
+ * The node's own OAuth2 client — a client-type identity that holds no
+ * management permission.
+ */
+function nodeClientActor(clientId: string): ActorContext {
+    return {
+        realm: { name: 'node-realm' },
+        identity: { type: 'client', id: clientId },
+        permissionChecker: { preCheck: async () => { throw new Error('forbidden'); } },
+    } as unknown as ActorContext;
+}
+
 const NODE_ID = randomUUID();
 
 function buildService(opts: { node?: Partial<Node>; secret?: string | null }) {
@@ -66,6 +78,24 @@ describe('NodeClientCredentialService', () => {
 
         const credentials = await service.getCredentials(NODE_ID, realmManagerActor('realm-b'));
         expect(credentials.secret).toBe('the-secret');
+    });
+
+    it('should return credentials for the node\'s own client without any permission', async () => {
+        const { service, reader } = buildService({ node: baseNode() });
+
+        const credentials = await service.getCredentials(NODE_ID, nodeClientActor('node-client-1'));
+
+        expect(credentials.secret).toBe('the-secret');
+        expect(reader.calls).toEqual(['node-client-1']);
+    });
+
+    it('should deny a foreign client', async () => {
+        const { service, reader } = buildService({ node: baseNode() });
+
+        await expect(
+            service.getCredentials(NODE_ID, nodeClientActor('some-other-client')),
+        ).rejects.toThrow(PermissionDeniedError);
+        expect(reader.calls).toHaveLength(0);
     });
 
     it('should deny a manager from a different realm', async () => {
@@ -128,6 +158,24 @@ describe('NodeClientCredentialService', () => {
             await service.setCredentials(NODE_ID, 'my-secret', createAllowAllActor());
 
             expect(reader.writes).toEqual([{ clientId: 'node-client-1', secret: 'my-secret' }]);
+        });
+
+        it('should let the node\'s own client rotate its credentials without any permission', async () => {
+            const { service, reader } = buildService({ node: baseNode() });
+
+            const credentials = await service.setCredentials(NODE_ID, undefined, nodeClientActor('node-client-1'));
+
+            expect(reader.writes).toEqual([{ clientId: 'node-client-1', secret: undefined }]);
+            expect(credentials.secret).toBe('generated-secret');
+        });
+
+        it('should deny a foreign client', async () => {
+            const { service, reader } = buildService({ node: baseNode() });
+
+            await expect(
+                service.setCredentials(NODE_ID, undefined, nodeClientActor('some-other-client')),
+            ).rejects.toThrow(PermissionDeniedError);
+            expect(reader.writes).toHaveLength(0);
         });
 
         it('should deny without permission', async () => {

--- a/apps/server-core/test/unit/core/services/client-credential/node.spec.ts
+++ b/apps/server-core/test/unit/core/services/client-credential/node.spec.ts
@@ -69,7 +69,12 @@ describe('NodeClientCredentialService', () => {
 
         const credentials = await service.getCredentials(NODE_ID, createAllowAllActor());
 
-        expect(credentials).toEqual({ id: 'node-client-1', secret: 'the-secret' });
+        expect(credentials).toEqual({
+            id: 'node-client-1',
+            name: 'the-name',
+            display_name: null,
+            secret: 'the-secret',
+        });
         expect(reader.calls).toEqual(['node-client-1']);
     });
 
@@ -146,26 +151,41 @@ describe('NodeClientCredentialService', () => {
         it('should rotate (no secret) for a manager', async () => {
             const { service, reader } = buildService({ node: baseNode() });
 
-            const credentials = await service.setCredentials(NODE_ID, undefined, createAllowAllActor());
+            const credentials = await service.setCredentials(NODE_ID, {}, createAllowAllActor());
 
-            expect(reader.writes).toEqual([{ clientId: 'node-client-1', secret: undefined }]);
+            expect(reader.writes).toEqual([{ clientId: 'node-client-1', data: {} }]);
             expect(credentials.secret).toBe('generated-secret');
         });
 
         it('should set a provided secret for a manager', async () => {
             const { service, reader } = buildService({ node: baseNode() });
 
-            await service.setCredentials(NODE_ID, 'my-secret', createAllowAllActor());
+            await service.setCredentials(NODE_ID, { secret: 'my-secret' }, createAllowAllActor());
 
-            expect(reader.writes).toEqual([{ clientId: 'node-client-1', secret: 'my-secret' }]);
+            expect(reader.writes).toEqual([{ clientId: 'node-client-1', data: { secret: 'my-secret' } }]);
+        });
+
+        it('should update the client name and display name', async () => {
+            const { service, reader } = buildService({ node: baseNode() });
+
+            await service.setCredentials(
+                NODE_ID,
+                { name: 'new-name', display_name: 'New Name' },
+                createAllowAllActor(),
+            );
+
+            expect(reader.writes).toEqual([{
+                clientId: 'node-client-1',
+                data: { name: 'new-name', display_name: 'New Name' },
+            }]);
         });
 
         it('should let the node\'s own client rotate its credentials without any permission', async () => {
             const { service, reader } = buildService({ node: baseNode() });
 
-            const credentials = await service.setCredentials(NODE_ID, undefined, nodeClientActor('node-client-1'));
+            const credentials = await service.setCredentials(NODE_ID, {}, nodeClientActor('node-client-1'));
 
-            expect(reader.writes).toEqual([{ clientId: 'node-client-1', secret: undefined }]);
+            expect(reader.writes).toEqual([{ clientId: 'node-client-1', data: {} }]);
             expect(credentials.secret).toBe('generated-secret');
         });
 
@@ -173,7 +193,7 @@ describe('NodeClientCredentialService', () => {
             const { service, reader } = buildService({ node: baseNode() });
 
             await expect(
-                service.setCredentials(NODE_ID, undefined, nodeClientActor('some-other-client')),
+                service.setCredentials(NODE_ID, {}, nodeClientActor('some-other-client')),
             ).rejects.toThrow(PermissionDeniedError);
             expect(reader.writes).toHaveLength(0);
         });
@@ -182,7 +202,7 @@ describe('NodeClientCredentialService', () => {
             const { service, reader } = buildService({ node: baseNode() });
 
             await expect(
-                service.setCredentials(NODE_ID, undefined, createDenyAllActor()),
+                service.setCredentials(NODE_ID, {}, createDenyAllActor()),
             ).rejects.toThrow();
             expect(reader.writes).toHaveLength(0);
         });
@@ -191,7 +211,7 @@ describe('NodeClientCredentialService', () => {
             const { service, reader } = buildService({ node: baseNode({ realm_id: 'realm-b' }) });
 
             await expect(
-                service.setCredentials(NODE_ID, undefined, realmManagerActor('realm-a')),
+                service.setCredentials(NODE_ID, {}, realmManagerActor('realm-a')),
             ).rejects.toThrow(PermissionDeniedError);
             expect(reader.writes).toHaveLength(0);
         });
@@ -200,7 +220,7 @@ describe('NodeClientCredentialService', () => {
             const { service } = buildService({ node: baseNode({ client_id: null }) });
 
             await expect(
-                service.setCredentials(NODE_ID, undefined, createAllowAllActor()),
+                service.setCredentials(NODE_ID, {}, createAllowAllActor()),
             ).rejects.toThrow(BadRequestError);
         });
     });

--- a/apps/server-core/test/unit/core/services/registry-credential/node.spec.ts
+++ b/apps/server-core/test/unit/core/services/registry-credential/node.spec.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { REALM_MASTER_NAME } from '@authup/core-kit';
+import type { Node, Registry, RegistryProject } from '@privateaim/core-kit';
+import { BadRequestError, EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
+import type { ActorContext } from '@privateaim/server-kit';
+import { createAllowAllActor } from '@privateaim/server-test-kit';
+import { describe, expect, it } from 'vitest';
+import { NodeRegistryCredentialService } from '../../../../../src/core/services/registry-credential/index.ts';
+import type {
+    INodeRepository,
+    IRegistryProjectRepository,
+    IRegistryRepository,
+} from '../../../../../src/core/index.ts';
+
+function createNodeRepository(nodes: Partial<Node>[]): INodeRepository {
+    return { findOneById: async (id: string) => nodes.find((n) => n.id === id) ?? null } as unknown as INodeRepository;
+}
+
+function createRegistryRepository(registries: Partial<Registry>[]): IRegistryRepository {
+    return { findOneById: async (id: string) => registries.find((r) => r.id === id) ?? null } as unknown as IRegistryRepository;
+}
+
+function createRegistryProjectRepository(projects: Partial<RegistryProject>[]): IRegistryProjectRepository {
+    return { findOneWithSecret: async (id: string) => projects.find((p) => p.id === id) ?? null } as unknown as IRegistryProjectRepository;
+}
+
+/**
+ * The node's own OAuth2 client — a client-type identity that holds no
+ * management permission, in a non-master realm.
+ */
+function nodeClientActor(clientId: string): ActorContext {
+    return {
+        realm: { name: 'node-realm' },
+        identity: { type: 'client', id: clientId },
+        permissionChecker: { preCheck: async () => { throw new Error('forbidden'); } },
+    } as unknown as ActorContext;
+}
+
+function userActor(): ActorContext {
+    return {
+        realm: { name: 'some-realm' },
+        identity: { type: 'user', id: randomUUID() },
+        // A plain user without REGISTRY_MANAGE.
+        permissionChecker: { preCheck: async () => { throw new Error('forbidden'); } },
+    } as unknown as ActorContext;
+}
+
+/**
+ * A master-realm member who does NOT hold REGISTRY_MANAGE — used to prove that
+ * realm membership alone never grants access.
+ */
+function masterRealmWithoutPermissionActor(): ActorContext {
+    return {
+        realm: { name: REALM_MASTER_NAME },
+        identity: { type: 'user', id: randomUUID() },
+        permissionChecker: { preCheck: async () => { throw new Error('forbidden'); } },
+    } as unknown as ActorContext;
+}
+
+const NODE_ID = randomUUID();
+const REGISTRY_ID = randomUUID();
+const REGISTRY_PROJECT_ID = randomUUID();
+
+function buildService(opts: {
+    node?: Partial<Node>;
+    registry?: Partial<Registry>;
+    registryProject?: Partial<RegistryProject>;
+}) {
+    return new NodeRegistryCredentialService({
+        repository: createNodeRepository(opts.node ? [opts.node] : []),
+        registryRepository: createRegistryRepository(opts.registry ? [opts.registry] : []),
+        registryProjectRepository: createRegistryProjectRepository(opts.registryProject ? [opts.registryProject] : []),
+    });
+}
+
+function baseNode(overrides: Partial<Node> = {}): Partial<Node> {
+    return {
+        id: NODE_ID,
+        realm_id: 'realm-b',
+        client_id: 'node-client-1',
+        registry_project_id: REGISTRY_PROJECT_ID,
+        ...overrides,
+    };
+}
+
+function baseRegistry(overrides: Partial<Registry> = {}): Partial<Registry> {
+    return {
+        id: REGISTRY_ID,
+        host: 'registry.example.com',
+        ...overrides,
+    };
+}
+
+function baseRegistryProject(overrides: Partial<RegistryProject> = {}): Partial<RegistryProject> {
+    return {
+        id: REGISTRY_PROJECT_ID,
+        registry_id: REGISTRY_ID,
+        external_name: 'node-project',
+        account_name: 'robot$node-project',
+        account_secret: 'the-secret',
+        ...overrides,
+    };
+}
+
+function fullSetup(node: Partial<Node> = baseNode()) {
+    return buildService({
+        node,
+        registry: baseRegistry(),
+        registryProject: baseRegistryProject(),
+    });
+}
+
+describe('NodeRegistryCredentialService', () => {
+    it('should return the registry credentials for a permitted manager', async () => {
+        const service = fullSetup();
+
+        const credentials = await service.getCredentials(NODE_ID, createAllowAllActor());
+
+        expect(credentials).toEqual({
+            host: 'registry.example.com',
+            external_name: 'node-project',
+            account_name: 'robot$node-project',
+            account_secret: 'the-secret',
+        });
+    });
+
+    it('should deny a master-realm member that lacks the permission', async () => {
+        // Realm membership is not a permission: without REGISTRY_MANAGE, even a
+        // master-realm member must be denied.
+        const service = fullSetup();
+
+        await expect(
+            service.getCredentials(NODE_ID, masterRealmWithoutPermissionActor()),
+        ).rejects.toThrow(PermissionDeniedError);
+    });
+
+    it('should return the registry credentials for the node\'s own client', async () => {
+        const service = fullSetup();
+
+        const credentials = await service.getCredentials(NODE_ID, nodeClientActor('node-client-1'));
+
+        expect(credentials.account_secret).toBe('the-secret');
+        expect(credentials.host).toBe('registry.example.com');
+    });
+
+    it('should deny a different client', async () => {
+        const service = fullSetup();
+
+        await expect(
+            service.getCredentials(NODE_ID, nodeClientActor('some-other-client')),
+        ).rejects.toThrow(PermissionDeniedError);
+    });
+
+    it('should deny a non-master user', async () => {
+        const service = fullSetup();
+
+        await expect(
+            service.getCredentials(NODE_ID, userActor()),
+        ).rejects.toThrow(PermissionDeniedError);
+    });
+
+    it('should deny the node\'s own client when the node has no client provisioned', async () => {
+        // A null client_id must never match a (also nullish) actor id.
+        const service = fullSetup(baseNode({ client_id: null }));
+
+        await expect(
+            service.getCredentials(NODE_ID, nodeClientActor('node-client-1')),
+        ).rejects.toThrow(PermissionDeniedError);
+    });
+
+    it('should 404 for an unknown node', async () => {
+        const service = fullSetup();
+
+        await expect(
+            service.getCredentials(randomUUID(), createAllowAllActor()),
+        ).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it('should reject when the node has no registry project provisioned', async () => {
+        const service = buildService({
+            node: baseNode({ registry_project_id: null }),
+            registry: baseRegistry(),
+            registryProject: baseRegistryProject(),
+        });
+
+        await expect(
+            service.getCredentials(NODE_ID, createAllowAllActor()),
+        ).rejects.toThrow(BadRequestError);
+    });
+
+    it('should reject when the registry project cannot be found', async () => {
+        const service = buildService({
+            node: baseNode(),
+            registry: baseRegistry(),
+            // no registry project seeded
+        });
+
+        await expect(
+            service.getCredentials(NODE_ID, createAllowAllActor()),
+        ).rejects.toThrow(BadRequestError);
+    });
+
+    it('should reject when the registry cannot be found', async () => {
+        const service = buildService({
+            node: baseNode(),
+            // no registry seeded
+            registryProject: baseRegistryProject(),
+        });
+
+        await expect(
+            service.getCredentials(NODE_ID, createAllowAllActor()),
+        ).rejects.toThrow(BadRequestError);
+    });
+
+    it('should authorize before exposing provisioning state', async () => {
+        // An unauthorized actor on an unprovisioned node must be denied, never
+        // leak provisioning state via BadRequestError.
+        const service = fullSetup(baseNode({ registry_project_id: null }));
+
+        await expect(
+            service.getCredentials(NODE_ID, userActor()),
+        ).rejects.toThrow(PermissionDeniedError);
+    });
+});

--- a/docs/src/reference/core/index.md
+++ b/docs/src/reference/core/index.md
@@ -51,7 +51,7 @@ See [Shared Configuration](/reference/#shared-configuration) and [Database Confi
 | `GET/POST/PUT/DELETE` | `/nodes` | Node CRUD |
 | `GET/POST/PUT/DELETE` | `/registries` | Registry CRUD |
 | `GET/POST/PUT/DELETE` | `/master-images` | Master image CRUD |
-| `GET/POST` | `/nodes/:id/client/credentials` | Read / rotate the node's OAuth2 client credentials (management permission required) |
+| `GET/POST` | `/nodes/:id/client/credentials` | Read / update the node's OAuth2 client credentials (secret, name, display name) — usable by the node's own client or a `NODE_UPDATE` manager |
 | `GET` | `/nodes/:id/registry/credentials` | Read the node's own registry project (Harbor robot) credentials — accessible to the node's own client without any management permission |
 | `GET/POST` | `/analyses/:id/client/credentials` | Read / rotate the analysis's OAuth2 client credentials |
 | `GET` | `/docs` | Swagger/OpenAPI documentation |

--- a/docs/src/reference/core/index.md
+++ b/docs/src/reference/core/index.md
@@ -51,6 +51,9 @@ See [Shared Configuration](/reference/#shared-configuration) and [Database Confi
 | `GET/POST/PUT/DELETE` | `/nodes` | Node CRUD |
 | `GET/POST/PUT/DELETE` | `/registries` | Registry CRUD |
 | `GET/POST/PUT/DELETE` | `/master-images` | Master image CRUD |
+| `GET/POST` | `/nodes/:id/client/credentials` | Read / rotate the node's OAuth2 client credentials (management permission required) |
+| `GET` | `/nodes/:id/registry/credentials` | Read the node's own registry project (Harbor robot) credentials — accessible to the node's own client without any management permission |
+| `GET/POST` | `/analyses/:id/client/credentials` | Read / rotate the analysis's OAuth2 client credentials |
 | `GET` | `/docs` | Swagger/OpenAPI documentation |
 
 ## Architecture

--- a/package-lock.json
+++ b/package-lock.json
@@ -26838,6 +26838,7 @@
             "version": "0.11.4",
             "license": "Apache-2.0",
             "devDependencies": {
+                "@authup/core-kit": "^1.0.0-beta.48",
                 "@authup/kit": "^1.0.0-beta.48",
                 "@privateaim/core-kit": "^0.11.4",
                 "@privateaim/telemetry-kit": "^0.11.4",
@@ -26846,6 +26847,7 @@
                 "vitest": "^4.1.7"
             },
             "peerDependencies": {
+                "@authup/core-kit": "^1.0.0-beta.48",
                 "@authup/kit": "^1.0.0-beta.48",
                 "@privateaim/core-kit": "^0.11.4",
                 "@privateaim/telemetry-kit": "^0.11.4",

--- a/packages/client-vue/src/components/node/FNodeClientCredentials.vue
+++ b/packages/client-vue/src/components/node/FNodeClientCredentials.vue
@@ -6,6 +6,7 @@
   -->
 <script lang="ts">
 import type { Node } from '@privateaim/core-kit';
+import type { NodeClientCredentialsUpdate } from '@privateaim/core-http-kit';
 import { useClipboard } from '@vueuse/core';
 import {
     type PropType,
@@ -29,13 +30,12 @@ export default defineComponent({
         const clipboard = useClipboard();
 
         const clientId = ref<string | null>(null);
-        const secret = ref<string | null>(null);
+        const name = ref<string>('');
+        const displayName = ref<string>('');
+        const secret = ref<string>('');
         const revealed = ref(false);
         const busy = ref(false);
         const loaded = ref(false);
-        // Rotating invalidates the current secret, so it is gated behind an
-        // inline confirm rather than firing on a single click.
-        const confirming = ref(false);
 
         const load = async () => {
             if (busy.value) {
@@ -46,9 +46,10 @@ export default defineComponent({
             // current one is (re)loaded — important because the parent reuses
             // this component across node ids.
             revealed.value = false;
-            confirming.value = false;
             clientId.value = null;
-            secret.value = null;
+            name.value = '';
+            displayName.value = '';
+            secret.value = '';
 
             if (!props.entity.client_id) {
                 loaded.value = true;
@@ -59,7 +60,9 @@ export default defineComponent({
             try {
                 const credentials = await httpClient.node.getClientCredentials(props.entity.id);
                 clientId.value = credentials.id;
-                secret.value = credentials.secret;
+                name.value = credentials.name ?? '';
+                displayName.value = credentials.display_name ?? '';
+                secret.value = credentials.secret ?? '';
             } catch (e) {
                 emit('failed', e);
             } finally {
@@ -83,23 +86,27 @@ export default defineComponent({
             revealed.value = !revealed.value;
         };
 
-        const cancelRegenerate = () => {
-            confirming.value = false;
-        };
-
-        const regenerate = async () => {
-            confirming.value = false;
-
+        const submit = async () => {
             if (busy.value || !props.entity.client_id) {
                 return;
             }
 
+            // The form is the desired state: a non-empty name/display-name is
+            // written, an empty secret rotates to a freshly generated one.
+            const data: NodeClientCredentialsUpdate = {
+                secret: secret.value ? secret.value : undefined,
+                name: name.value ? name.value : undefined,
+                display_name: displayName.value ? displayName.value : null,
+            };
+
             busy.value = true;
             try {
-                const credentials = await httpClient.node.setClientCredentials(props.entity.id);
+                const credentials = await httpClient.node.setClientCredentials(props.entity.id, data);
                 clientId.value = credentials.id;
-                secret.value = credentials.secret;
-                // Reveal the freshly generated secret so the admin can copy it.
+                name.value = credentials.name ?? '';
+                displayName.value = credentials.display_name ?? '';
+                secret.value = credentials.secret ?? '';
+                // Reveal the freshly written secret so the admin can copy it.
                 revealed.value = true;
             } catch (e) {
                 emit('failed', e);
@@ -110,15 +117,15 @@ export default defineComponent({
 
         return {
             busy,
-            confirming,
             loaded,
             clientId,
+            name,
+            displayName,
             secret,
             revealed,
             copy,
             toggleReveal,
-            regenerate,
-            cancelRegenerate,
+            submit,
         };
     },
 });
@@ -148,9 +155,10 @@ export default defineComponent({
             />
             <span>Loading credentials…</span>
         </div>
-        <div
+        <form
             v-else
             class="flex flex-col gap-2"
+            @submit.prevent="submit"
         >
             <VCFormGroup :label-class="'w-full mb-1'">
                 <template #label>
@@ -178,6 +186,24 @@ export default defineComponent({
 
             <VCFormGroup :label-class="'w-full mb-1'">
                 <template #label>
+                    Name
+                </template>
+                <template #default>
+                    <VCFormInput v-model="name" />
+                </template>
+            </VCFormGroup>
+
+            <VCFormGroup :label-class="'w-full mb-1'">
+                <template #label>
+                    Display Name
+                </template>
+                <template #default>
+                    <VCFormInput v-model="displayName" />
+                </template>
+            </VCFormGroup>
+
+            <VCFormGroup :label-class="'w-full mb-1'">
+                <template #label>
                     <div class="flex flex-row">
                         <div>Secret</div>
                         <div class="ms-auto flex flex-row gap-1">
@@ -197,43 +223,27 @@ export default defineComponent({
                             >
                                 <VCIcon name="fa6-solid:copy" /> Copy
                             </button>
-                            <button
-                                v-if="!confirming"
-                                type="button"
-                                class="btn btn-xs btn-danger"
-                                :disabled="busy"
-                                @click.prevent="confirming = true"
-                            >
-                                <VCIcon name="fa6-solid:rotate" /> Regenerate
-                            </button>
-                            <template v-else>
-                                <button
-                                    type="button"
-                                    class="btn btn-xs btn-danger"
-                                    :disabled="busy"
-                                    @click.prevent="regenerate"
-                                >
-                                    Confirm
-                                </button>
-                                <button
-                                    type="button"
-                                    class="btn btn-xs btn-dark"
-                                    @click.prevent="cancelRegenerate"
-                                >
-                                    Cancel
-                                </button>
-                            </template>
                         </div>
                     </div>
                 </template>
                 <template #default>
                     <VCFormInput
-                        :model-value="secret"
+                        v-model="secret"
                         :type="revealed ? 'text' : 'password'"
-                        :readonly="true"
                     />
+                    <small class="text-secondary">Leave empty to generate a new secret.</small>
                 </template>
             </VCFormGroup>
-        </div>
+
+            <div class="flex flex-row">
+                <button
+                    type="submit"
+                    class="btn btn-primary btn-sm ms-auto"
+                    :disabled="busy"
+                >
+                    <VCIcon name="fa6-solid:floppy-disk" /> Update
+                </button>
+            </div>
+        </form>
     </div>
 </template>

--- a/packages/client-vue/src/components/node/FNodeRegistryCredentials.vue
+++ b/packages/client-vue/src/components/node/FNodeRegistryCredentials.vue
@@ -1,0 +1,237 @@
+<!--
+  - Copyright (c) 2024.
+  - Author Peter Placzek (tada5hi)
+  - For the full copyright and license information,
+  - view the LICENSE file that was distributed with this source code.
+  -->
+<script lang="ts">
+import type { Node } from '@privateaim/core-kit';
+import { useClipboard } from '@vueuse/core';
+import {
+    type PropType,
+    defineComponent,
+    onMounted,
+    ref,
+    watch,
+} from 'vue';
+import { injectCoreHTTPClient } from '../../core';
+
+export default defineComponent({
+    props: {
+        entity: {
+            type: Object as PropType<Node>,
+            required: true,
+        },
+    },
+    emits: ['failed'],
+    setup(props, { emit }) {
+        const httpClient = injectCoreHTTPClient();
+        const clipboard = useClipboard();
+
+        const host = ref<string | null>(null);
+        const externalName = ref<string | null>(null);
+        const accountName = ref<string | null>(null);
+        const accountSecret = ref<string | null>(null);
+        const revealed = ref(false);
+        const busy = ref(false);
+        const loaded = ref(false);
+
+        const load = async () => {
+            if (busy.value) {
+                return;
+            }
+
+            // Reset so a previous node's credentials never linger while the
+            // current one is (re)loaded — important because the parent reuses
+            // this component across node ids.
+            revealed.value = false;
+            host.value = null;
+            externalName.value = null;
+            accountName.value = null;
+            accountSecret.value = null;
+
+            if (!props.entity.registry_project_id) {
+                loaded.value = true;
+                return;
+            }
+
+            busy.value = true;
+            try {
+                const credentials = await httpClient.node.getRegistryCredentials(props.entity.id);
+                host.value = credentials.host;
+                externalName.value = credentials.external_name;
+                accountName.value = credentials.account_name;
+                accountSecret.value = credentials.account_secret;
+            } catch (e) {
+                emit('failed', e);
+            } finally {
+                busy.value = false;
+                loaded.value = true;
+            }
+        };
+
+        onMounted(load);
+        watch(() => props.entity.id, load);
+
+        const copy = (value: string | null) => {
+            if (!value) {
+                return;
+            }
+
+            clipboard.copy(value);
+        };
+
+        const toggleReveal = () => {
+            revealed.value = !revealed.value;
+        };
+
+        return {
+            busy,
+            loaded,
+            host,
+            externalName,
+            accountName,
+            accountSecret,
+            revealed,
+            copy,
+            toggleReveal,
+        };
+    },
+});
+</script>
+<template>
+    <div>
+        <h6>Registry Credentials</h6>
+
+        <p>
+            These credentials let the node authenticate against the docker registry of its
+            registry project (robot account). Keep the secret confidential.
+        </p>
+
+        <div
+            v-if="!entity.registry_project_id"
+            class="alert alert-sm alert-warning"
+        >
+            The node has no registry project provisioned yet.
+        </div>
+        <div
+            v-else-if="busy || !loaded"
+            class="flex flex-row items-center gap-2"
+        >
+            <VCIcon
+                name="fa6-solid:circle-notch"
+                class="animate-spin"
+            />
+            <span>Loading credentials…</span>
+        </div>
+        <div
+            v-else
+            class="flex flex-col gap-2"
+        >
+            <VCFormGroup :label-class="'w-full mb-1'">
+                <template #label>
+                    <div class="flex flex-row">
+                        <div>Host</div>
+                        <div class="ms-auto">
+                            <button
+                                type="button"
+                                class="btn btn-xs btn-dark"
+                                :disabled="!host"
+                                @click.prevent="copy(host)"
+                            >
+                                <VCIcon name="fa6-solid:copy" /> Copy
+                            </button>
+                        </div>
+                    </div>
+                </template>
+                <template #default>
+                    <VCFormInput
+                        :model-value="host"
+                        :readonly="true"
+                    />
+                </template>
+            </VCFormGroup>
+
+            <VCFormGroup :label-class="'w-full mb-1'">
+                <template #label>
+                    <div class="flex flex-row">
+                        <div>Project</div>
+                        <div class="ms-auto">
+                            <button
+                                type="button"
+                                class="btn btn-xs btn-dark"
+                                :disabled="!externalName"
+                                @click.prevent="copy(externalName)"
+                            >
+                                <VCIcon name="fa6-solid:copy" /> Copy
+                            </button>
+                        </div>
+                    </div>
+                </template>
+                <template #default>
+                    <VCFormInput
+                        :model-value="externalName"
+                        :readonly="true"
+                    />
+                </template>
+            </VCFormGroup>
+
+            <VCFormGroup :label-class="'w-full mb-1'">
+                <template #label>
+                    <div class="flex flex-row">
+                        <div>Account Name</div>
+                        <div class="ms-auto">
+                            <button
+                                type="button"
+                                class="btn btn-xs btn-dark"
+                                :disabled="!accountName"
+                                @click.prevent="copy(accountName)"
+                            >
+                                <VCIcon name="fa6-solid:copy" /> Copy
+                            </button>
+                        </div>
+                    </div>
+                </template>
+                <template #default>
+                    <VCFormInput
+                        :model-value="accountName"
+                        :readonly="true"
+                    />
+                </template>
+            </VCFormGroup>
+
+            <VCFormGroup :label-class="'w-full mb-1'">
+                <template #label>
+                    <div class="flex flex-row">
+                        <div>Secret</div>
+                        <div class="ms-auto flex flex-row gap-1">
+                            <button
+                                type="button"
+                                class="btn btn-xs btn-dark"
+                                @click.prevent="toggleReveal"
+                            >
+                                <VCIcon :name="revealed ? 'fa6-solid:eye-slash' : 'fa6-solid:eye'" />
+                                {{ revealed ? 'Hide' : 'Reveal' }}
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-xs btn-dark"
+                                :disabled="!accountSecret"
+                                @click.prevent="copy(accountSecret)"
+                            >
+                                <VCIcon name="fa6-solid:copy" /> Copy
+                            </button>
+                        </div>
+                    </div>
+                </template>
+                <template #default>
+                    <VCFormInput
+                        :model-value="accountSecret"
+                        :type="revealed ? 'text' : 'password'"
+                        :readonly="true"
+                    />
+                </template>
+            </VCFormGroup>
+        </div>
+    </div>
+</template>

--- a/packages/client-vue/src/components/node/index.ts
+++ b/packages/client-vue/src/components/node/index.ts
@@ -10,3 +10,4 @@ export { default as FNodeCrypto } from './FNodeCrypto.vue';
 export { default as FNodes } from './FNodes';
 export { default as FNodeRegistryProject } from './FNodeRegistryProject';
 export { default as FNodeClientCredentials } from './FNodeClientCredentials.vue';
+export { default as FNodeRegistryCredentials } from './FNodeRegistryCredentials.vue';

--- a/packages/core-http-kit/package.json
+++ b/packages/core-http-kit/package.json
@@ -24,6 +24,7 @@
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts"
     },
     "devDependencies": {
+        "@authup/core-kit": "^1.0.0-beta.48",
         "@authup/kit": "^1.0.0-beta.48",
         "@privateaim/core-kit": "^0.11.4",
         "@privateaim/telemetry-kit": "^0.11.4",
@@ -32,6 +33,7 @@
         "vitest": "^4.1.7"
     },
     "peerDependencies": {
+        "@authup/core-kit": "^1.0.0-beta.48",
         "@authup/kit": "^1.0.0-beta.48",
         "@privateaim/core-kit": "^0.11.4",
         "@privateaim/telemetry-kit": "^0.11.4",

--- a/packages/core-http-kit/src/domains/node/module.ts
+++ b/packages/core-http-kit/src/domains/node/module.ts
@@ -13,6 +13,7 @@ import type { CollectionResourceResponse, SingleResourceResponse } from '../type
 import { nullifyEmptyObjectProperties } from '../../utils';
 import type {
     NodeClientCredentials,
+    NodeClientCredentialsUpdate,
     NodeCreatePayload,
     NodeRegistryCredentials,
     NodeUpdatePayload,
@@ -62,11 +63,12 @@ export class NodeAPI extends BaseAPI {
     }
 
     /**
-     * Rotate (or, when a secret is given, set) the node client's credentials.
+     * Update the node client's credentials. An omitted `secret` rotates to a
+     * fresh one; an omitted `name` / `display_name` leaves that field unchanged.
      * Returns the new credentials once.
      */
-    async setClientCredentials(id: Node['id'], secret?: string): Promise<NodeClientCredentials> {
-        const response = await this.client.post(`nodes/${id}/client/credentials`, { secret });
+    async setClientCredentials(id: Node['id'], data?: NodeClientCredentialsUpdate): Promise<NodeClientCredentials> {
+        const response = await this.client.post(`nodes/${id}/client/credentials`, data ?? {});
 
         return response.data;
     }

--- a/packages/core-http-kit/src/domains/node/module.ts
+++ b/packages/core-http-kit/src/domains/node/module.ts
@@ -11,7 +11,12 @@ import type { Node } from '@privateaim/core-kit';
 import { BaseAPI } from '../base';
 import type { CollectionResourceResponse, SingleResourceResponse } from '../types-base';
 import { nullifyEmptyObjectProperties } from '../../utils';
-import type { NodeClientCredentials, NodeCreatePayload, NodeUpdatePayload } from './types';
+import type {
+    NodeClientCredentials,
+    NodeCreatePayload,
+    NodeRegistryCredentials,
+    NodeUpdatePayload,
+} from './types';
 
 export class NodeAPI extends BaseAPI {
     async getMany(options?: BuildInput<Node>): Promise<CollectionResourceResponse<Node>> {
@@ -62,6 +67,17 @@ export class NodeAPI extends BaseAPI {
      */
     async setClientCredentials(id: Node['id'], secret?: string): Promise<NodeClientCredentials> {
         const response = await this.client.post(`nodes/${id}/client/credentials`, { secret });
+
+        return response.data;
+    }
+
+    /**
+     * Read the node's own registry project credentials (Harbor robot account)
+     * so it can authenticate against the docker registry. Accessible to the
+     * node's own client without holding any management permission.
+     */
+    async getRegistryCredentials(id: Node['id']): Promise<NodeRegistryCredentials> {
+        const response = await this.client.get(`nodes/${id}/registry/credentials`);
 
         return response.data;
     }

--- a/packages/core-http-kit/src/domains/node/types.ts
+++ b/packages/core-http-kit/src/domains/node/types.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Node } from '@privateaim/core-kit';
+import type { Node, Registry, RegistryProject } from '@privateaim/core-kit';
 
 export type NodeCreatePayload =    & Pick<Node, 'name'> &
     Partial<Pick<Node, 'type' | 'hidden' | 'public_key' | 'external_name' | 'registry_id' | 'client_id' | 'realm_id'>>;
@@ -16,3 +16,6 @@ export type NodeClientCredentials = {
     id: string;
     secret: string | null;
 };
+
+export type NodeRegistryCredentials =    & Pick<Registry, 'host' | 'account_name' | 'account_secret'> &
+    Pick<RegistryProject, 'external_name'>;

--- a/packages/core-http-kit/src/domains/node/types.ts
+++ b/packages/core-http-kit/src/domains/node/types.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Client } from '@authup/core-kit';
 import type { Node, Registry, RegistryProject } from '@privateaim/core-kit';
 
 export type NodeCreatePayload =    & Pick<Node, 'name'> &
@@ -12,10 +13,9 @@ export type NodeCreatePayload =    & Pick<Node, 'name'> &
 
 export type NodeUpdatePayload = Partial<NodeCreatePayload>;
 
-export type NodeClientCredentials = {
-    id: string;
-    secret: string | null;
-};
+export type NodeClientCredentials = Pick<Client, 'id' | 'name' | 'display_name' | 'secret'>;
+
+export type NodeClientCredentialsUpdate = Partial<Pick<Client, 'secret' | 'name' | 'display_name'>>;
 
 export type NodeRegistryCredentials =    & Pick<Registry, 'host' | 'account_name' | 'account_secret'> &
     Pick<RegistryProject, 'external_name'>;


### PR DESCRIPTION
## Summary

Lets a node's **own** OAuth2 client read its registry credentials (and manage its client credentials) without holding any management permission, hardens the credential-authorization rule so **realm membership is never treated as a permission**, and surfaces the registry credentials in the admin UI.

## API

### New route — `GET /nodes/:id/registry/credentials`

Returns what a node needs to authenticate against its own docker registry project (Harbor robot account): registry `host`, project `external_name`, and the project-scoped `account_name` / `account_secret`. `RegistryCredentials` is projected from the domain types:

```ts
export type RegistryCredentials =
    & Pick<Registry, 'host' | 'account_name' | 'account_secret'>
    & Pick<RegistryProject, 'external_name'>;
```

**Authorization (fail-closed):** the node's own client may always read; any other caller must hold `REGISTRY_MANAGE` (the same permission that gates this secret on the registry-project endpoint).

### Node client credentials — own client may now self-manage

`GET/POST /nodes/:id/client/credentials` previously required `NODE_UPDATE` outright. The node's own client may now **read and rotate** its own client credentials without any management permission; every other caller still needs `NODE_UPDATE` + realm-write access.

## Authorization hardening — membership is not a permission

The credential read paths granted access to any master-realm member outright (`isActorMasterRealmMember`), bypassing the permission checker. All credential services now follow **referenced identity OR an actual permission check**:

| Service | Referenced identity (no permission needed) | Otherwise requires |
|---|---|---|
| `NodeRegistryCredentialService` | the node's own client | `REGISTRY_MANAGE` |
| `NodeClientCredentialService` (get + set) | the node's own client | `NODE_UPDATE` + realm-write |
| `AnalysisClientCredentialService` | client of an **approved, assigned** node | `ANALYSIS_UPDATE` |

A master-realm member *with* the permission still passes; one *without* it is now denied — closing the hole. Audited the rest of `server-core`: the only instances of the anti-pattern were these `isAuthorized` methods; other `REALM_MASTER_NAME` / `isRealmResourceWritable` uses are legitimate realm-*scoping* or run *after* a permission check.

## UI

`FNodeRegistryCredentials` — a reveal/copy panel (mirroring the node client-credentials panel) that reads the node's registry credentials via the dedicated endpoint. Rendered on the admin node **Registry** tab above the existing registry-project configuration.

## Other changes

- `findOneWithSecret()` on the registry-project repository/port
- `core-http-kit`: `NodeAPI.getRegistryCredentials()` + `NodeRegistryCredentials`
- Docs: documented the credential-delivery endpoints

## Tests

- New `NodeRegistryCredentialService` suite (11 cases) + new node/analysis cases incl. *"deny a master-realm member that lacks the permission"* and *"own client may read/rotate without permission"*
- 277/277 server-core core unit tests pass; `tsc`, `vue-tsc` (client-vue) + ESLint clean

## Open questions for review

- Permission choice: `REGISTRY_MANAGE` (node registry route), `NODE_UPDATE` (node client route), `ANALYSIS_UPDATE` (analysis route). Used `preCheck` (name-only) to match existing secret gates rather than `check()` with resource attributes — easy to switch.
- `external_name` is included in `RegistryCredentials` for the push/pull path; happy to drop it for a pure `Pick<Registry>`.
- The Registry tab now shows both the credentials panel and the full registry-project config; tell me if you'd prefer only the panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added registry credentials viewer for nodes with read-only display and copy-to-clipboard functionality
  * Enhanced node client credentials management with editable name and display name fields; secret can be rotated by leaving the field empty
  * New REST endpoints for retrieving and managing node registry and client credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->