### PR TITLE
fix: ship dist directory in published kit packages

### DIFF
--- a/packages/core-http-kit/package.json
+++ b/packages/core-http-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/core-realtime-kit/package.json
+++ b/packages/core-realtime-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/messenger-http-kit/package.json
+++ b/packages/messenger-http-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/messenger-kit/package.json
+++ b/packages/messenger-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-core-worker-kit/package.json
+++ b/packages/server-core-worker-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-db-kit/package.json
+++ b/packages/server-db-kit/package.json
@@ -4,6 +4,9 @@
     "version": "0.11.4",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-http-kit/package.json
+++ b/packages/server-http-kit/package.json
@@ -4,6 +4,9 @@
     "version": "0.11.4",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-kit/package.json
+++ b/packages/server-kit/package.json
@@ -4,6 +4,9 @@
     "version": "0.11.4",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-realtime-kit/package.json
+++ b/packages/server-realtime-kit/package.json
@@ -4,6 +4,9 @@
     "version": "0.11.4",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-storage-kit/package.json
+++ b/packages/server-storage-kit/package.json
@@ -4,6 +4,9 @@
     "version": "0.11.4",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-telemetry-kit/package.json
+++ b/packages/server-telemetry-kit/package.json
@@ -4,6 +4,9 @@
     "version": "0.11.4",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/server-test-kit/package.json
+++ b/packages/server-test-kit/package.json
@@ -13,6 +13,9 @@
     },
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",

--- a/packages/storage-kit/package.json
+++ b/packages/storage-kit/package.json
@@ -13,6 +13,9 @@
     },
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "author": {
         "name": "Peter Placzek",
         "email": "admin@tada5hi.net",

--- a/packages/telemetry-kit/package.json
+++ b/packages/telemetry-kit/package.json
@@ -6,6 +6,9 @@
     "description": "",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "files": [
+        "dist"
+    ],
     "exports": {
         "./package.json": "./package.json",
         ".": {


### PR DESCRIPTION
## Problem

16 of the `packages/*` kits had **no `files` field** in `package.json`. With no `.npmignore` anywhere in the repo, npm falls back to the root `.gitignore` — which ignores `dist` (line 80). So these packages published `src/` + `test/` but **no `dist/`**, even though their `module` / `types` / `exports` all point at `./dist/...`. The published tarballs were unusable by external consumers.

This stayed invisible because apps consume kits via workspace refs (built locally). It surfaced in **plan 013 Track B** — the new `node-message-broker` repo (a separate repo, first external consumer of the *published* `@privateaim/*` packages). Installed `@privateaim/{kit,messenger-kit,server-kit,server-http-kit}@0.11.4` shipped `src/` but had `dist` **missing**.

## Fix

Add `"files": ["dist"]` to the 16 kits that lacked it, matching the convention already used by `errors`, `client-vue`, and `client-vue-theme`.

## Verification

`npm pack --dry-run` per package:

| | before | after |
|---|---|---|
| `core-kit` | 88 files — all `src`/`test`, **0 `dist`** | 7 files — `dist/*` + `LICENSE` + `README` + `package.json` |

Every fixed kit now ships exactly `dist/{index.mjs,index.mjs.map,index.d.mts,index.d.mts.map}` and drops the `src`/`test` bloat.

## Follow-up

A republish (release-please bump → monoship) is required so the node repo can pull working tarballs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution configurations across 16 packages to optimize published artifacts and refine package structure for npm distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->