### PR TITLE
refactor(server-messenger): align MessageEntity column types and indexes

### DIFF
--- a/apps/server-messenger/src/adapters/database/entities/message.ts
+++ b/apps/server-messenger/src/adapters/database/entities/message.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { deserialize, serialize } from '@authup/kit';
 import type { Message, MessageData, MessageMetadata } from '@privateaim/messenger-kit';
 import {
     Column,
@@ -18,10 +19,9 @@ import {
  * The durable mailbox. Append-only: one row per recipient, delivered delete-on-ack.
  * Pulls are ordered by `created_at` (relative ordering is timezone-independent) and
  * scoped to `recipient_id`; `data` is opaque to the hub (base64 E2E ciphertext for
- * analysis messaging). `expires_at` is an absolute epoch (ms) used by the TTL sweep —
- * a bigint, so the comparison is timezone-immune (unlike a zone-less datetime).
+ * analysis messaging). `expires_at` is an absolute datetime used by the TTL sweep.
  */
-@Index(['recipient_id', 'created_at'])
+@Index(['recipient_id', 'created_at', 'id'])
 @Index(['expires_at'])
 @Entity({ name: 'messages' })
 export class MessageEntity implements Message {
@@ -40,16 +40,30 @@ export class MessageEntity implements Message {
     @Column({ type: 'uuid' })
     recipient_id!: string;
 
-    @Column({ type: 'simple-json', nullable: true })
+    @Column({
+        type: 'text',
+        nullable: true,
+        transformer: {
+            to: (value: MessageData): string => serialize(value),
+            from: (value: string | null): MessageData => deserialize<MessageData>(value),
+        },
+    })
     data!: MessageData;
 
-    @Column({ type: 'simple-json', nullable: true })
+    @Column({
+        type: 'text',
+        nullable: true,
+        transformer: {
+            to: (value: MessageMetadata | null): string => serialize(value),
+            from: (value: string | null): MessageMetadata | null => deserialize<MessageMetadata | null>(value),
+        },
+    })
     metadata!: MessageMetadata | null;
 
     @CreateDateColumn()
     created_at!: Date;
 
-    /** absolute expiry, epoch milliseconds (bigint, stored as a string by typeorm) */
-    @Column({ type: 'bigint' })
-    expires_at!: string;
+    /** absolute expiry timestamp; the TTL sweep deletes rows past it */
+    @Column({ type: Date })
+    expires_at!: Date;
 }

--- a/apps/server-messenger/src/adapters/database/migrations/mysql/1782138800821-Default.ts
+++ b/apps/server-messenger/src/adapters/database/migrations/mysql/1782138800821-Default.ts
@@ -14,16 +14,16 @@ export class Default1782138800821 implements MigrationInterface {
                 \`data\` text NULL,
                 \`metadata\` text NULL,
                 \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-                \`expires_at\` bigint NOT NULL,
+                \`expires_at\` datetime NOT NULL,
                 INDEX \`IDX_3a83b1bc057fd8dd8ffcc926ca\` (\`expires_at\`),
-                INDEX \`IDX_6f3011974e71494d267c3b9df5\` (\`recipient_id\`, \`created_at\`),
+                INDEX \`IDX_f4070ef2c27d60b10b2083ffcc\` (\`recipient_id\`, \`created_at\`, \`id\`),
                 PRIMARY KEY (\`id\`)
             ) ENGINE = InnoDB
         `);
     }
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX \`IDX_6f3011974e71494d267c3b9df5\` ON \`messages\`
+            DROP INDEX \`IDX_f4070ef2c27d60b10b2083ffcc\` ON \`messages\`
         `);
         await queryRunner.query(`
             DROP INDEX \`IDX_3a83b1bc057fd8dd8ffcc926ca\` ON \`messages\`

--- a/apps/server-messenger/src/adapters/database/migrations/postgres/1782138800821-Default.ts
+++ b/apps/server-messenger/src/adapters/database/migrations/postgres/1782138800821-Default.ts
@@ -14,7 +14,7 @@ export class Default1782138800821 implements MigrationInterface {
                 "data" text,
                 "metadata" text,
                 "created_at" TIMESTAMP NOT NULL DEFAULT now(),
-                "expires_at" bigint NOT NULL,
+                "expires_at" TIMESTAMP NOT NULL,
                 CONSTRAINT "PK_18325f38ae6de43878487eff986" PRIMARY KEY ("id")
             )
         `);
@@ -22,12 +22,12 @@ export class Default1782138800821 implements MigrationInterface {
             CREATE INDEX "IDX_3a83b1bc057fd8dd8ffcc926ca" ON "messages" ("expires_at")
         `);
         await queryRunner.query(`
-            CREATE INDEX "IDX_6f3011974e71494d267c3b9df5" ON "messages" ("recipient_id", "created_at")
+            CREATE INDEX "IDX_f4070ef2c27d60b10b2083ffcc" ON "messages" ("recipient_id", "created_at", "id")
         `);
     }
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX "public"."IDX_6f3011974e71494d267c3b9df5"
+            DROP INDEX "public"."IDX_f4070ef2c27d60b10b2083ffcc"
         `);
         await queryRunner.query(`
             DROP INDEX "public"."IDX_3a83b1bc057fd8dd8ffcc926ca"

--- a/apps/server-messenger/src/app/modules/database/repositories/message/repository.ts
+++ b/apps/server-messenger/src/app/modules/database/repositories/message/repository.ts
@@ -62,7 +62,7 @@ export class MessageRepositoryAdapter implements IMessageRepository {
         const result = await this.repository.createQueryBuilder()
             .delete()
             .from(MessageEntity)
-            .where('expires_at < :now', { now: now.getTime() })
+            .where('expires_at < :now', { now })
             .execute();
 
         return result.affected ?? 0;

--- a/apps/server-messenger/src/core/entities/message/service.ts
+++ b/apps/server-messenger/src/core/entities/message/service.ts
@@ -53,7 +53,7 @@ export class MessageService implements IMessageService {
         const sender = this.requireIdentity(actor);
         const recipients = this.validateRecipients(data);
 
-        const expiresAt = `${Date.now() + this.ttlMs}`;
+        const expiresAt = new Date(Date.now() + this.ttlMs);
 
         const input: MessagePersistInput[] = recipients.map((recipient) => ({
             sender_type: sender.type,

--- a/apps/server-messenger/src/core/entities/message/types.ts
+++ b/apps/server-messenger/src/core/entities/message/types.ts
@@ -17,10 +17,10 @@ import type { ActorContext } from '@privateaim/server-kit';
 
 /**
  * The writable fields of a message — `id` and `created_at` are generated.
- * `expires_at` is an absolute epoch (ms), set by the sender (TTL).
+ * `expires_at` is an absolute expiry timestamp, set from the TTL at send time.
  */
 export type MessagePersistInput = Omit<Message, 'id' | 'created_at'> & {
-    expires_at: string;
+    expires_at: Date;
 };
 
 export interface IMessageRepository {

--- a/apps/server-messenger/test/unit/core/entities/message/fake-repository.ts
+++ b/apps/server-messenger/test/unit/core/entities/message/fake-repository.ts
@@ -9,7 +9,7 @@ import { randomUUID } from 'node:crypto';
 import type { Message, MessageParty } from '@privateaim/messenger-kit';
 import type { IMessageRepository, MessagePersistInput } from '../../../../../src/core/entities/message/types.ts';
 
-type StoredMessage = Message & { expires_at: string };
+type StoredMessage = Message & { expires_at: Date };
 
 export class FakeMessageRepository implements IMessageRepository {
     public messages: StoredMessage[] = [];
@@ -51,7 +51,7 @@ export class FakeMessageRepository implements IMessageRepository {
     async deleteExpired(now: Date): Promise<number> {
         const before = this.messages.length;
         const cutoff = now.getTime();
-        this.messages = this.messages.filter((message) => Number(message.expires_at) >= cutoff);
+        this.messages = this.messages.filter((message) => message.expires_at.getTime() >= cutoff);
         return before - this.messages.length;
     }
 }

--- a/apps/server-messenger/test/unit/core/entities/message/repository.spec.ts
+++ b/apps/server-messenger/test/unit/core/entities/message/repository.spec.ts
@@ -27,7 +27,7 @@ function persistInput(recipientId: string, data: string, expiresAtEpoch = Date.n
         recipient_id: recipientId,
         data,
         metadata: { analysisId: 'analysis-1' },
-        expires_at: `${expiresAtEpoch}`,
+        expires_at: new Date(expiresAtEpoch),
     };
 }
 


### PR DESCRIPTION
## Summary

Aligns the durable mailbox entity (`MessageEntity`, plan 013 Track A) with the monorepo's established persistence conventions and tightens its indexing for the pull hot path. Pre-release internal cleanup — no public API or behavioral change.

## Changes

- **`data` / `metadata`** — replace TypeORM `simple-json` with a `text` column + a `serialize`/`deserialize` transformer from `@authup/kit`, matching the pattern already used by `server-telemetry` (`event`) and `server-core` (`analysis`). `simple-json` already compiled to `text`, so the column SQL is unchanged.
- **`expires_at`** — store as a datetime column (`@Column({ type: Date })`) instead of `bigint` epoch-ms. Epoch-ms never needed 64-bit range, and a datetime matches every other date column in the repo. The TTL sweep now compares a `Date` param (serialized consistently per-driver across pg/mysql/sqlite) rather than a raw integer.
- **recipient index** — append `id` → `(recipient_id, created_at, id)` so the pull `ORDER BY created_at, id LIMIT n` is a pure index range scan with no sort step on same-instant ties. The TypeORM index-name hash was recomputed (verified by reproducing the two existing hashes byte-for-byte).

Migrations (`1782138800821-Default.ts`, postgres + mysql) are **edited in place** since nothing has been released yet — no follow-up migration.

## Index coverage (verified complete)

The `IMessageRepository` port is the entire query surface — every path is served:

| Operation | Query | Served by |
|-----------|-------|-----------|
| `findManyForRecipient` (pull) | `WHERE recipient_id (+type) ORDER BY created_at, id LIMIT n` | `(recipient_id, created_at, id)` |
| `ackByIds` | `DELETE WHERE recipient (+type) AND id IN (...)` | PK on `id` |
| `deleteExpired` (sweep) | `DELETE WHERE expires_at < ?` | `(expires_at)` |

No sender-side queries exist, so no sender index is added.

## Testing

- `npx nx test server-messenger` — 20/20 pass (sqlite)
- `npx nx build server-messenger` — clean (tsdown + `tsc` type-check)
- lint clean