### PR TITLE
refactor: represent entity timestamps as ISO-8601 strings (type + runtime transformer)

### DIFF
--- a/apps/server-core/src/adapters/database/entities/analysis-bucket-file.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-bucket-file.ts
@@ -84,10 +84,10 @@ export class AnalysisBucketFileEntity implements AnalysisBucketFile {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 }

--- a/apps/server-core/src/adapters/database/entities/analysis-bucket-file.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-bucket-file.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import type { 
     Client, 
     Realm, 
@@ -83,10 +84,10 @@ export class AnalysisBucketFileEntity implements AnalysisBucketFile {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/entities/analysis-bucket.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-bucket.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import type {
     Analysis, 
     AnalysisBucket, 
@@ -51,9 +52,9 @@ export class AnalysisBucketEntity implements AnalysisBucket {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/analysis-bucket.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-bucket.ts
@@ -52,8 +52,8 @@ export class AnalysisBucketEntity implements AnalysisBucket {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/analysis-node-event.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-node-event.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -31,10 +32,10 @@ export class AnalysisNodeEventEntity implements AnalysisNodeEvent {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/entities/analysis-node-event.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-node-event.ts
@@ -32,10 +32,10 @@ export class AnalysisNodeEventEntity implements AnalysisNodeEvent {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/entities/analysis-node.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-node.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -78,10 +79,10 @@ export class AnalysisNodeEntity implements AnalysisNode {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/entities/analysis-node.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis-node.ts
@@ -79,10 +79,10 @@ export class AnalysisNodeEntity implements AnalysisNode {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/entities/analysis.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis.ts
@@ -13,7 +13,7 @@ import type {
     Project,
     Registry,
 } from '@privateaim/core-kit';
-import { bigintNumberTransformer } from '@privateaim/server-db-kit';
+import { bigintNumberTransformer, dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -192,10 +192,10 @@ export class AnalysisEntity implements Analysis {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/entities/analysis.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis.ts
@@ -193,10 +193,10 @@ export class AnalysisEntity implements Analysis {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/entities/master-image-group.ts
+++ b/apps/server-core/src/adapters/database/entities/master-image-group.ts
@@ -33,8 +33,8 @@ export class MasterImageGroupEntity implements MasterImageGroup {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/master-image-group.ts
+++ b/apps/server-core/src/adapters/database/entities/master-image-group.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -32,9 +33,9 @@ export class MasterImageGroupEntity implements MasterImageGroup {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/master-image.ts
+++ b/apps/server-core/src/adapters/database/entities/master-image.ts
@@ -7,7 +7,7 @@
 
 import { deserialize, serialize } from '@authup/kit';
 import type { ProcessStatus } from '@privateaim/kit';
-import { bigintNumberTransformer } from '@privateaim/server-db-kit';
+import { bigintNumberTransformer, dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -95,9 +95,9 @@ export class MasterImageEntity implements MasterImage {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/master-image.ts
+++ b/apps/server-core/src/adapters/database/entities/master-image.ts
@@ -96,8 +96,8 @@ export class MasterImageEntity implements MasterImage {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/node.ts
+++ b/apps/server-core/src/adapters/database/entities/node.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -87,9 +88,9 @@ export class NodeEntity implements Node {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/node.ts
+++ b/apps/server-core/src/adapters/database/entities/node.ts
@@ -88,8 +88,8 @@ export class NodeEntity implements Node {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/project-node.ts
+++ b/apps/server-core/src/adapters/database/entities/project-node.ts
@@ -44,10 +44,10 @@ export class ProjectNodeEntity implements ProjectNode {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/entities/project-node.ts
+++ b/apps/server-core/src/adapters/database/entities/project-node.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn, 
@@ -43,10 +44,10 @@ export class ProjectNodeEntity implements ProjectNode {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/entities/project.ts
+++ b/apps/server-core/src/adapters/database/entities/project.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column, 
     CreateDateColumn, 
@@ -64,10 +65,10 @@ export class ProjectEntity implements Project {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/entities/project.ts
+++ b/apps/server-core/src/adapters/database/entities/project.ts
@@ -65,10 +65,10 @@ export class ProjectEntity implements Project {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/entities/registry-project.ts
+++ b/apps/server-core/src/adapters/database/entities/registry-project.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -113,9 +114,9 @@ export class RegistryProjectEntity implements RegistryProject {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/registry-project.ts
+++ b/apps/server-core/src/adapters/database/entities/registry-project.ts
@@ -114,8 +114,8 @@ export class RegistryProjectEntity implements RegistryProject {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/registry.ts
+++ b/apps/server-core/src/adapters/database/entities/registry.ts
@@ -48,8 +48,8 @@ export class RegistryEntity implements Registry {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/entities/registry.ts
+++ b/apps/server-core/src/adapters/database/entities/registry.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import {
     Column,
     CreateDateColumn,
@@ -47,9 +48,9 @@ export class RegistryEntity implements Registry {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/test/unit/date-transformer.spec.ts
+++ b/apps/server-core/test/unit/date-transformer.spec.ts
@@ -1,0 +1,38 @@
+import {
+    afterAll, 
+    beforeAll, 
+    describe, 
+    expect, 
+    it,
+} from 'vitest';
+import { MasterImageGroupEntity } from '../../src/adapters/database/entities/master-image-group.ts';
+import { createTestDatabaseApplication } from '../app/factory.ts';
+import type { TestApplication } from '../app/module.ts';
+
+describe('date-to-iso-string transformer', () => {
+    let app: TestApplication;
+
+    beforeAll(async () => {
+        app = createTestDatabaseApplication();
+        await app.setup();
+    });
+
+    afterAll(async () => {
+        await app.teardown();
+    });
+
+    it('hydrates created_at and updated_at as ISO strings on a fresh read', async () => {
+        const repo = app.dataSource.getRepository(MasterImageGroupEntity);
+        const saved = await repo.save(repo.create({
+            name: 'g', 
+            path: '/p', 
+            virtual_path: '/vp', 
+        }));
+        const read = await repo.findOneByOrFail({ id: saved.id });
+
+        expect(typeof read.created_at).toBe('string');
+        expect(typeof read.updated_at).toBe('string');
+        expect(Number.isNaN(new Date(read.created_at).getTime())).toBe(false);
+        expect(Number.isNaN(new Date(read.updated_at).getTime())).toBe(false);
+    });
+});

--- a/apps/server-messenger/src/adapters/database/entities/message.ts
+++ b/apps/server-messenger/src/adapters/database/entities/message.ts
@@ -61,9 +61,9 @@ export class MessageEntity implements Message {
     metadata!: MessageMetadata | null;
 
     @CreateDateColumn()
-    created_at!: Date;
+    created_at!: string;
 
     /** absolute expiry timestamp; the TTL sweep deletes rows past it */
     @Column({ type: Date })
-    expires_at!: Date;
+    expires_at!: string;
 }

--- a/apps/server-messenger/src/adapters/database/entities/message.ts
+++ b/apps/server-messenger/src/adapters/database/entities/message.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import { deserialize, serialize } from '@authup/kit';
 import type { Message, MessageData, MessageMetadata } from '@privateaim/messenger-kit';
 import {
@@ -60,10 +61,10 @@ export class MessageEntity implements Message {
     })
     metadata!: MessageMetadata | null;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at!: string;
 
     /** absolute expiry timestamp; the TTL sweep deletes rows past it */
-    @Column({ type: Date })
+    @Column({ type: Date, transformer: dateToISOStringTransformer })
     expires_at!: string;
 }

--- a/apps/server-messenger/src/core/entities/message/service.ts
+++ b/apps/server-messenger/src/core/entities/message/service.ts
@@ -53,7 +53,7 @@ export class MessageService implements IMessageService {
         const sender = this.requireIdentity(actor);
         const recipients = this.validateRecipients(data);
 
-        const expiresAt = new Date(Date.now() + this.ttlMs);
+        const expiresAt = new Date(Date.now() + this.ttlMs).toISOString();
 
         const input: MessagePersistInput[] = recipients.map((recipient) => ({
             sender_type: sender.type,

--- a/apps/server-messenger/src/core/entities/message/types.ts
+++ b/apps/server-messenger/src/core/entities/message/types.ts
@@ -17,10 +17,10 @@ import type { ActorContext } from '@privateaim/server-kit';
 
 /**
  * The writable fields of a message — `id` and `created_at` are generated.
- * `expires_at` is an absolute expiry timestamp, set from the TTL at send time.
+ * `expires_at` is an absolute expiry timestamp (ISO-8601), set from the TTL at send time.
  */
 export type MessagePersistInput = Omit<Message, 'id' | 'created_at'> & {
-    expires_at: Date;
+    expires_at: string;
 };
 
 export interface IMessageRepository {

--- a/apps/server-messenger/test/unit/core/entities/message/fake-repository.ts
+++ b/apps/server-messenger/test/unit/core/entities/message/fake-repository.ts
@@ -9,7 +9,7 @@ import { randomUUID } from 'node:crypto';
 import type { Message, MessageParty } from '@privateaim/messenger-kit';
 import type { IMessageRepository, MessagePersistInput } from '../../../../../src/core/entities/message/types.ts';
 
-type StoredMessage = Message & { expires_at: Date };
+type StoredMessage = Message & { expires_at: string };
 
 export class FakeMessageRepository implements IMessageRepository {
     public messages: StoredMessage[] = [];
@@ -22,8 +22,8 @@ export class FakeMessageRepository implements IMessageRepository {
             const message: StoredMessage = {
                 ...item,
                 id: randomUUID(),
-                // monotonic timestamp so ordering is deterministic in tests
-                created_at: new Date(Date.now() + this.counter),
+                // monotonic ISO timestamp so ordering is deterministic in tests
+                created_at: new Date(Date.now() + this.counter).toISOString(),
             };
             this.messages.push(message);
             return message;
@@ -33,7 +33,7 @@ export class FakeMessageRepository implements IMessageRepository {
     async findManyForRecipient(recipient: MessageParty, limit: number): Promise<Message[]> {
         return this.messages
             .filter((message) => message.recipient_type === recipient.type && message.recipient_id === recipient.id)
-            .sort((a, b) => (a.created_at.getTime() - b.created_at.getTime()) || a.id.localeCompare(b.id))
+            .sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))
             .slice(0, limit);
     }
 
@@ -51,7 +51,7 @@ export class FakeMessageRepository implements IMessageRepository {
     async deleteExpired(now: Date): Promise<number> {
         const before = this.messages.length;
         const cutoff = now.getTime();
-        this.messages = this.messages.filter((message) => message.expires_at.getTime() >= cutoff);
+        this.messages = this.messages.filter((message) => new Date(message.expires_at).getTime() >= cutoff);
         return before - this.messages.length;
     }
 }

--- a/apps/server-messenger/test/unit/core/entities/message/repository.spec.ts
+++ b/apps/server-messenger/test/unit/core/entities/message/repository.spec.ts
@@ -27,7 +27,7 @@ function persistInput(recipientId: string, data: string, expiresAtEpoch = Date.n
         recipient_id: recipientId,
         data,
         metadata: { analysisId: 'analysis-1' },
-        expires_at: new Date(expiresAtEpoch),
+        expires_at: new Date(expiresAtEpoch).toISOString(),
     };
 }
 
@@ -54,7 +54,8 @@ describe('database/message-repository', () => {
 
         expect(created).toHaveLength(2);
         expect(created[0].id).toBeDefined();
-        expect(created[0].created_at).toBeInstanceOf(Date);
+        expect(created[0].created_at).toBeDefined();
+        expect(Number.isNaN(new Date(created[0].created_at).getTime())).toBe(false);
         expect(created[0].metadata).toEqual({ analysisId: 'analysis-1' });
     });
 

--- a/apps/server-storage/src/adapters/database/entities/bucket-file.ts
+++ b/apps/server-storage/src/adapters/database/entities/bucket-file.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Realm } from '@authup/core-kit';
-import { bigintNumberTransformer } from '@privateaim/server-db-kit';
+import { bigintNumberTransformer, dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import type { BucketFile } from '@privateaim/storage-kit';
 import {
     Column,
@@ -48,10 +48,10 @@ export class BucketFileEntity implements BucketFile {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-storage/src/adapters/database/entities/bucket-file.ts
+++ b/apps/server-storage/src/adapters/database/entities/bucket-file.ts
@@ -49,10 +49,10 @@ export class BucketFileEntity implements BucketFile {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-storage/src/adapters/database/entities/bucket.ts
+++ b/apps/server-storage/src/adapters/database/entities/bucket.ts
@@ -33,10 +33,10 @@ export class BucketEntity implements Bucket {
     // ------------------------------------------------------------------
 
     @CreateDateColumn()
-    created_at: Date;
+    created_at: string;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-storage/src/adapters/database/entities/bucket.ts
+++ b/apps/server-storage/src/adapters/database/entities/bucket.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import type { Realm } from '@authup/core-kit';
 import type { Bucket } from '@privateaim/storage-kit';
 import {
@@ -32,10 +33,10 @@ export class BucketEntity implements Bucket {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-telemetry/src/adapters/database/entities/event.ts
+++ b/apps/server-telemetry/src/adapters/database/entities/event.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { dateToISOStringTransformer } from '@privateaim/server-db-kit';
 import type { Realm } from '@authup/core-kit';
 import { deserialize, serialize } from '@authup/kit';
 import type { ObjectLiteral } from '@privateaim/kit';
@@ -137,9 +138,9 @@ export class EventEntity implements Event {
     })
     expires_at: string | null;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/packages/core-kit/src/domains/analysis-bucket-file/entity.ts
+++ b/packages/core-kit/src/domains/analysis-bucket-file/entity.ts
@@ -23,9 +23,9 @@ export interface AnalysisBucketFile {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/analysis-bucket/entity.ts
+++ b/packages/core-kit/src/domains/analysis-bucket/entity.ts
@@ -30,7 +30,7 @@ export interface AnalysisBucket {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/analysis-node-event/entity.ts
+++ b/packages/core-kit/src/domains/analysis-node-event/entity.ts
@@ -15,9 +15,9 @@ export interface AnalysisNodeEvent {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/analysis-node/entity.ts
+++ b/packages/core-kit/src/domains/analysis-node/entity.ts
@@ -36,9 +36,9 @@ export interface AnalysisNode {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/analysis/entity.ts
+++ b/packages/core-kit/src/domains/analysis/entity.ts
@@ -113,9 +113,9 @@ export interface Analysis {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/master-image-group/entity.ts
+++ b/packages/core-kit/src/domains/master-image-group/entity.ts
@@ -16,7 +16,7 @@ export interface MasterImageGroup {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/master-image/entity.ts
+++ b/packages/core-kit/src/domains/master-image/entity.ts
@@ -33,7 +33,7 @@ export interface MasterImage {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/node/entity.ts
+++ b/packages/core-kit/src/domains/node/entity.ts
@@ -50,7 +50,7 @@ export interface Node {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/project-node/entity.ts
+++ b/packages/core-kit/src/domains/project-node/entity.ts
@@ -19,9 +19,9 @@ export interface ProjectNode {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/project/entity.ts
+++ b/packages/core-kit/src/domains/project/entity.ts
@@ -37,9 +37,9 @@ export interface Project {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/registry-project/entity.ts
+++ b/packages/core-kit/src/domains/registry-project/entity.ts
@@ -51,7 +51,7 @@ export interface RegistryProject {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/registry/entity.ts
+++ b/packages/core-kit/src/domains/registry/entity.ts
@@ -20,7 +20,7 @@ export interface Registry {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/messenger-http-kit/src/domains/message/module.ts
+++ b/packages/messenger-http-kit/src/domains/message/module.ts
@@ -6,7 +6,6 @@
  */
 
 import type {
-    Message,
     MessageAckRequest,
     MessagePullQuery,
     MessagePullResponse,
@@ -31,11 +30,6 @@ function buildPullQuery(query?: MessagePullQuery): string {
     return serialized.length > 0 ? `?${serialized}` : '';
 }
 
-function rehydrate(message: Message): Message {
-    // JSON transports created_at as a string; restore the Date contract
-    return { ...message, created_at: new Date(message.created_at) };
-}
-
 export class MessageAPI extends BaseAPI {
     /**
      * Send a message to one or more recipients. The sender is the authenticated
@@ -54,7 +48,7 @@ export class MessageAPI extends BaseAPI {
      */
     async pull(query?: MessagePullQuery): Promise<MessagePullResponse> {
         const { data } = await this.client.get(`messages${buildPullQuery(query)}`);
-        return { messages: (data.messages ?? []).map(rehydrate) };
+        return { messages: data.messages ?? [] };
     }
 
     /**

--- a/packages/messenger-http-kit/src/domains/message/module.ts
+++ b/packages/messenger-http-kit/src/domains/message/module.ts
@@ -48,7 +48,7 @@ export class MessageAPI extends BaseAPI {
      */
     async pull(query?: MessagePullQuery): Promise<MessagePullResponse> {
         const { data } = await this.client.get(`messages${buildPullQuery(query)}`);
-        return { messages: data.messages ?? [] };
+        return { messages: Array.isArray(data.messages) ? data.messages : [] };
     }
 
     /**

--- a/packages/messenger-kit/src/broker/message/types.ts
+++ b/packages/messenger-kit/src/broker/message/types.ts
@@ -53,7 +53,8 @@ export interface Message {
 
     metadata: MessageMetadata | null;
 
-    created_at: Date;
+    /** ISO-8601 timestamp; serialized form crossing every transport (HTTP/AMQP/socket) */
+    created_at: string;
 }
 
 /**

--- a/packages/server-db-kit/src/transformer/date-iso-string.ts
+++ b/packages/server-db-kit/src/transformer/date-iso-string.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ValueTransformer } from 'typeorm';
+
+/**
+ * TypeORM hydrates `datetime` columns (incl. `@CreateDateColumn` /
+ * `@UpdateDateColumn`) to JS `Date` objects by default — `pg`/`mysql2` return
+ * `Date` natively, and the sqlite driver normalizes the stored string to a
+ * `Date`. This transformer normalizes the read value to an ISO-8601 `string`,
+ * so the in-process runtime type matches the entity's declared `string` type
+ * *and* the JSON form delivered to clients — one timestamp type across backend
+ * and frontend, with no per-consumer re-hydration.
+ *
+ * Writes pass the value through unchanged; TypeORM serializes a `Date` or an
+ * ISO string to the underlying column type as usual.
+ */
+export const dateToISOStringTransformer: ValueTransformer = {
+    to(value: Date | string | null | undefined): Date | string | null | undefined {
+        return value;
+    },
+    from(value: Date | string | null | undefined): string | null | undefined {
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+
+        return value;
+    },
+};

--- a/packages/server-db-kit/src/transformer/index.ts
+++ b/packages/server-db-kit/src/transformer/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './bigint-number.ts';
+export * from './date-iso-string.ts';

--- a/packages/server-db-kit/test/unit/date-iso-string.spec.ts
+++ b/packages/server-db-kit/test/unit/date-iso-string.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { dateToISOStringTransformer } from '../../src/transformer/date-iso-string.ts';
+
+describe('dateToISOStringTransformer', () => {
+    it('from() converts a Date to an ISO-8601 string', () => {
+        const date = new Date('2026-06-23T15:37:03.000Z');
+        expect(dateToISOStringTransformer.from(date)).toBe('2026-06-23T15:37:03.000Z');
+    });
+
+    it('from() passes an existing string through unchanged', () => {
+        expect(dateToISOStringTransformer.from('2026-06-23T15:37:03.000Z')).toBe('2026-06-23T15:37:03.000Z');
+    });
+
+    it('from() passes null / undefined through unchanged', () => {
+        expect(dateToISOStringTransformer.from(null)).toBeNull();
+        expect(dateToISOStringTransformer.from(undefined)).toBeUndefined();
+    });
+
+    it('to() passes the value through unchanged (write path)', () => {
+        const date = new Date('2026-06-23T15:37:03.000Z');
+        expect(dateToISOStringTransformer.to(date)).toBe(date);
+        expect(dateToISOStringTransformer.to('2026-06-23T15:37:03.000Z')).toBe('2026-06-23T15:37:03.000Z');
+        expect(dateToISOStringTransformer.to(null)).toBeNull();
+    });
+});

--- a/packages/storage-kit/src/domains/bucket-file/entity.ts
+++ b/packages/storage-kit/src/domains/bucket-file/entity.ts
@@ -23,9 +23,9 @@ export interface BucketFile {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/storage-kit/src/domains/bucket/entity.ts
+++ b/packages/storage-kit/src/domains/bucket/entity.ts
@@ -16,9 +16,9 @@ export interface Bucket {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to #1721. Unifies how the hub represents entity timestamps: every `created_at` / `updated_at` / `expires_at` is an ISO-8601 **string** — both in the TypeScript type **and** at runtime — so there is a single timestamp type across backend and frontend, with no per-consumer re-hydration.

## Background — two layers were needed

1. **Type.** The shared domain contracts (`core-kit` / `storage-kit` / `messenger-kit`) and their entities typed timestamps as `Date`. But across HTTP / AMQP / socket boundaries, JSON only ever carries an ISO **string** — a `Date`-typed contract is inaccurate at every boundary and forces consumers to re-hydrate (`messenger-http-kit` had exactly such a `rehydrate()` hack). Only `server-telemetry`'s `event` already used `string`.
2. **Runtime.** Typing alone is not enough: TypeORM hydrates `@CreateDateColumn` / `@UpdateDateColumn` / `datetime` columns to `Date` objects **in-process** (`pg`/`mysql2` native; sqlite normalized via `normalizeHydratedDate`). So a `string` type without a transformer was still a `Date` at runtime on the backend. A shared value transformer normalizes the read value to an ISO string, making the runtime genuinely match the declared type.

## Changes

**Typing → `string` (ISO-8601):**
- `core-kit` + `server-core` — 12 entities (`created_at`/`updated_at`)
- `storage-kit` + `server-storage` — 2 entities (`bucket`, `bucket-file`)
- `messenger-kit` + `server-messenger` — `Message.created_at`, `expires_at`

**Runtime → `dateToISOStringTransformer` (`server-db-kit`, new):**
- read: `Date` → ISO string; write: pass-through
- applied to every `@CreateDateColumn`/`@UpdateDateColumn`/`datetime` column across `server-core`, `server-storage`, `server-messenger`, and `server-telemetry`

**Other:**
- `messenger-http-kit` — dropped the now-redundant `created_at` `rehydrate()` hack; added an array guard on `pull()`

No DB / migration changes — `@CreateDateColumn` etc. and the column SQL types are untouched; only the TS types plus a value transformer.

## No consumer fixes needed

The codebase was already defensive about strings:
- `isAnalysisProcessStale(updatedAt: Date | string)` — already parses via `new Date()`
- `useUpdatedAt` composable — already typed `string | Date`
- `VCTimeago :datetime` — accepts an ISO string
- no date-method calls (`.getTime()`, etc.) on these fields anywhere

## Verification

- **Runtime probe** — a fresh repository read returns `created_at` as `"2026-06-23T15:37:03.000Z"` (**string**), not a `Date`
- **Full build** — all 26 projects (incl. client-vue `vue-tsc` + client-ui Nuxt) type-check with `string`
- **Full test** — 11 projects (server-core 403, server-messenger 20, …)
- **Lint** clean; repo-wide audit: zero timestamp fields still typed `Date`

## Review

Addressed the CodeRabbit review (Date/string runtime mismatch on the entities, plus the `pull()` array guard). The mismatch was resolved by **transforming to a raw ISO string** rather than reverting the type to `Date` — that keeps one timestamp type across backend and frontend instead of a `Date` every consumer must convert.

## Related

- Follows #1721
- authup-side equivalent (authup is mid-migration too): authup/authup#3143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized timestamp representation across server, storage, analysis, and messaging models to ISO-8601 strings for consistent cross-platform/API behavior.
  * Updated message expiration handling to use ISO-8601 strings end-to-end during send/persistence and related unit logic.
  * Adjusted message API pull behavior so timestamps are no longer rehydrated into date objects, aligning outputs with the new string-based contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->