### PR TITLE
feat(client-vue): confirm destructive delete & assignment removal via AlertDialog

### DIFF
--- a/apps/client-ui/layouts/default.vue
+++ b/apps/client-ui/layouts/default.vue
@@ -40,9 +40,10 @@ export default defineNuxtComponent({
             Single host for the imperative useAlertDialog() confirmation API
             (e.g. <FEntityDelete>'s delete prompt and the assignment toggles'
             removal prompt). The AlertDialogManager is provided app-wide by
-            `app.use(installOverlays)` in plugins/vuecs.ts, so one provider under
-            the authenticated shell drains confirmations from every page. Placed
-            beside the toaster, not context-scoped like <VCToastProvider>.
+            `app.use(installOverlays)` in plugins/vuecs.ts, so this host can sit
+            anywhere under the shell and still drain confirmations from every
+            page — it is not a Reka context provider like <VCToastProvider>
+            (which is why it nests here without being scoped to any subtree).
         -->
         <VCAlertDialogProvider />
     </VCToastProvider>

--- a/apps/client-ui/layouts/default.vue
+++ b/apps/client-ui/layouts/default.vue
@@ -6,7 +6,7 @@
   -->
 <script lang="ts">
 
-import { VCToastProvider } from '@vuecs/overlays';
+import { VCAlertDialogProvider, VCToastProvider } from '@vuecs/overlays';
 import PageHeader from '../components/layout/header.vue';
 import PageSidebar from '../components/layout/sidebar.vue';
 import PageFooter from '../components/layout/footer.vue';
@@ -17,6 +17,7 @@ export default defineNuxtComponent({
         PageHeader,
         PageSidebar,
         PageFooter,
+        VCAlertDialogProvider,
         VCToastProvider,
     },
 });
@@ -34,6 +35,16 @@ export default defineNuxtComponent({
             </div>
             <PageFooter />
         </div>
+
+        <!--
+            Single host for the imperative useAlertDialog() confirmation API
+            (e.g. <FEntityDelete>'s delete prompt and the assignment toggles'
+            removal prompt). The AlertDialogManager is provided app-wide by
+            `app.use(installOverlays)` in plugins/vuecs.ts, so one provider under
+            the authenticated shell drains confirmations from every page. Placed
+            beside the toaster, not context-scoped like <VCToastProvider>.
+        -->
+        <VCAlertDialogProvider />
     </VCToastProvider>
 </template>
 <style>

--- a/packages/client-vue/src/components/FEntityDelete.ts
+++ b/packages/client-vue/src/components/FEntityDelete.ts
@@ -193,14 +193,33 @@ export default defineComponent({
         const onClick = async ($event: any) => {
             $event.preventDefault();
 
+            // Re-entrancy guard: a fast double-click could otherwise stack two
+            // confirmation dialogs (or fire two deletes) before submit() flips
+            // `busy`, since the button stays enabled while confirmDialog() is
+            // pending.
+            if (busy.value) {
+                return undefined;
+            }
+
             if (props.withPrompt && confirmDialog) {
-                const confirmed = await confirmDialog({
-                    title: promptTitle.value,
-                    description: promptDescription.value,
-                    confirmLabel: translation.value,
-                    cancelLabel: abortLabel.value,
-                    tone: 'error',
-                });
+                // Mark busy across the confirmation so the button is disabled
+                // while the dialog is open, then release it before submit() —
+                // which owns `busy` for the delete request and early-returns if
+                // it is still set. No await between the release and submit(), so
+                // no re-entrancy window reopens.
+                busy.value = true;
+                let confirmed: boolean;
+                try {
+                    confirmed = await confirmDialog({
+                        title: promptTitle.value,
+                        description: promptDescription.value,
+                        confirmLabel: translation.value,
+                        cancelLabel: abortLabel.value,
+                        tone: 'error',
+                    });
+                } finally {
+                    busy.value = false;
+                }
 
                 if (!confirmed) {
                     return undefined;

--- a/packages/client-vue/src/components/FEntityDelete.ts
+++ b/packages/client-vue/src/components/FEntityDelete.ts
@@ -6,10 +6,15 @@
  */
 
 import { useTranslation } from '@authup/client-web-kit';
-import { TranslatorTranslationActionKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import {
+    TranslatorTranslationActionKey,
+    TranslatorTranslationAppKey,
+    TranslatorTranslationNamespace,
+} from '@authup/i18n';
 import { VCButton } from '@vuecs/button';
 import type { ButtonColor, ButtonSize, ButtonVariant } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
+import { useAlertDialog } from '@vuecs/overlays';
 import type { DomainType as CoreDomainType } from '@privateaim/core-kit';
 import type { DomainType as StorageDomainType } from '@privateaim/storage-kit';
 import type { DomainType as TelemetryDomainType } from '@privateaim/telemetry-kit';
@@ -91,6 +96,14 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+
+        // Gate the (irreversible) delete behind a confirmation dialog rendered
+        // by the app-level <VCAlertDialogProvider> via useAlertDialog(). On by
+        // default — opt out per call site with :with-prompt="false".
+        withPrompt: {
+            type: Boolean,
+            default: true,
+        },
     },
     emits: ['deleted', 'failed'],
     setup(props, ctx) {
@@ -146,13 +159,58 @@ export default defineComponent({
             key: TranslatorTranslationActionKey.DELETE,
         });
 
+        // Imperative confirmation dialog, resolved ONLY when prompting is
+        // enabled — so `<FEntityDelete :with-prompt="false">` never injects the
+        // AlertDialogManager and therefore doesn't require the app-level
+        // <VCAlertDialogProvider>. `useAlertDialog()` only calls inject() (no
+        // lifecycle hooks), so this one-time conditional resolution in setup is
+        // safe. It resolves true (Delete) / false (Abort / Escape).
+        const confirmDialog = props.withPrompt ? useAlertDialog() : undefined;
+
+        // Singular, localized entity noun (`count: 1`) interpolated into the
+        // confirmation title. Hub entity types are not part of authup's ENTITY
+        // namespace, so most fall back to the raw key (e.g. "node") — still
+        // readable, and superseded once the hub ships its own i18n catalog.
+        const entityLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.ENTITY,
+            key: props.entityType,
+            count: 1,
+        });
+        const abortLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.ACTION,
+            key: TranslatorTranslationActionKey.ABORT,
+        });
+        const promptTitle = useTranslation({
+            namespace: TranslatorTranslationNamespace.APP,
+            key: TranslatorTranslationAppKey.DELETE_CONFIRM_TITLE,
+            data: { entity: entityLabel },
+        });
+        const promptDescription = useTranslation({
+            namespace: TranslatorTranslationNamespace.APP,
+            key: TranslatorTranslationAppKey.DELETE_CONFIRM_DESCRIPTION,
+        });
+
+        const onClick = async ($event: any) => {
+            $event.preventDefault();
+
+            if (props.withPrompt && confirmDialog) {
+                const confirmed = await confirmDialog({
+                    title: promptTitle.value,
+                    description: promptDescription.value,
+                    confirmLabel: translation.value,
+                    cancelLabel: abortLabel.value,
+                    tone: 'error',
+                });
+
+                if (!confirmed) {
+                    return undefined;
+                }
+            }
+
+            return submit();
+        };
+
         const render = () => {
-            const onClick = ($event: any) => {
-                $event.preventDefault();
-
-                return submit.apply(null);
-            };
-
             // Default (button) path — mirrors authup's <AEntityDelete>: a
             // self-styled <VCButton> with the icon via `iconLeft` (leading
             // span) and text via `label`, so hub + authup delete buttons

--- a/packages/client-vue/src/components/analysis-node/FAnalysisNodeAssignAction.ts
+++ b/packages/client-vue/src/components/analysis-node/FAnalysisNodeAssignAction.ts
@@ -5,13 +5,13 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { defineComponent } from 'vue';
+import { defineComponent, h } from 'vue';
 import type { AnalysisNode } from '@privateaim/core-kit';
 import {
     DomainType,
 } from '@privateaim/core-kit';
 import { createEntityManager, defineEntityManagerEvents } from '../../core';
-import { renderToggleButton } from '@authup/client-web-kit';
+import { AToggleButton } from '@authup/client-web-kit';
 
 export default defineComponent({
     props: {
@@ -23,7 +23,11 @@ export default defineComponent({
             type: String,
             required: true,
         },
-        realmId: String,
+        realmId: { type: String },
+        withPrompt: {
+            type: Boolean,
+            default: true,
+        },
     },
     emits: defineEntityManagerEvents<AnalysisNode>(),
     async setup(props, setup) {
@@ -47,10 +51,13 @@ export default defineComponent({
             },
         });
 
-        return () => renderToggleButton({
+        // withPrompt confirms only the removal transition (assigned →
+        // un-assign) via useAlertDialog(); adding a node never prompts.
+        return () => h(AToggleButton, {
             isBusy: manager.busy.value,
             value: !!manager.data.value,
-            changed: (value) => {
+            withPrompt: props.withPrompt,
+            onChanged: (value: boolean) => {
                 if (value) {
                     return manager.create({
                         analysis_id: props.analysisId,

--- a/packages/client-vue/src/components/project-node/FProjectNodeAssignAction.ts
+++ b/packages/client-vue/src/components/project-node/FProjectNodeAssignAction.ts
@@ -5,13 +5,13 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { defineComponent } from 'vue';
+import { defineComponent, h } from 'vue';
 import type { ProjectNode } from '@privateaim/core-kit';
 import {
     DomainType,
 } from '@privateaim/core-kit';
 import { createEntityManager, defineEntityManagerEvents } from '../../core';
-import { renderToggleButton } from '@authup/client-web-kit';
+import { AToggleButton } from '@authup/client-web-kit';
 
 export default defineComponent({
     props: {
@@ -23,7 +23,11 @@ export default defineComponent({
             type: String,
             required: true,
         },
-        realmId: String,
+        realmId: { type: String },
+        withPrompt: {
+            type: Boolean,
+            default: true,
+        },
     },
     emits: defineEntityManagerEvents<ProjectNode>(),
     async setup(props, setup) {
@@ -48,10 +52,13 @@ export default defineComponent({
             },
         });
 
-        return () => renderToggleButton({
+        // withPrompt confirms only the removal transition (assigned →
+        // un-assign) via useAlertDialog(); adding a node never prompts.
+        return () => h(AToggleButton, {
             isBusy: manager.busy.value,
             value: !!manager.data.value,
-            changed: (value) => {
+            withPrompt: props.withPrompt,
+            onChanged: (value: boolean) => {
                 if (value) {
                     return manager.create({
                         project_id: props.projectId,


### PR DESCRIPTION
## Summary

Applies the confirmation-dialog pattern from [authup#3173](https://github.com/authup/authup/pull/3173) to the hub UI: destructive/high-stakes actions now route through `@vuecs/overlays`' imperative `useAlertDialog()` (`tone: 'error'`), rendered by a single app-level `<VCAlertDialogProvider>`.

The prerequisite `@vuecs/overlays@1.2.0` (ships `useAlertDialog` + `VCAlertDialogProvider`) and `@authup/i18n@beta.51` (`deleteConfirm*` / `removeConfirm*` keys in all 4 locales) were already installed via the earlier `@vuecs`/`@authup` bump, and `app.use(installOverlays)` (which provides the `AlertDialogManager`) is already wired in `plugins/vuecs.ts` — so only the component/wiring changes were needed here.

## Changes

### Entity deletion — `FEntityDelete`
- Gains a **`withPrompt`** prop (**default on**; opt out per call site with `:with-prompt="false"`). Delete confirms with a localized title/description (`deleteConfirmTitle` / `deleteConfirmDescription`), reusing the existing `DELETE` (confirm) / `ABORT` (cancel) action labels.
- The dialog is resolved only when prompting is enabled, so `:with-prompt="false"` never injects the manager and doesn't require the provider.

### Assignment removal — node toggles
- `FProjectNodeAssignAction` and `FAnalysisNodeAssignAction` swap the promptless `renderToggleButton` helper for authup's updated **`<AToggleButton>`** component (which now carries `withPrompt`). Only the **removal transition** (assigned → un-assign) confirms; adding a node never prompts (removal stays reversible). `withPrompt` is exposed as a prop (default on), and the component also adds an `aria-label`.

### Host
- `apps/client-ui/layouts/default.vue` mounts a single `<VCAlertDialogProvider>` beside the toaster, so one host drains confirmations from every authenticated page.

## Notes
- Hub entity nouns aren't part of authup's `ENTITY` i18n namespace, so delete titles fall back to the raw key (e.g. *"Delete node?"*) — readable, matches authup's documented fallback, and will improve once the hub ships its own i18n catalog.

## Testing
- ✅ `eslint` clean on all changed files.
- ✅ `nx build client-vue` passes, including `vue-tsc` type-checking of the three TS components.
- ⚠️ Not click-tested live (needs the full stack + a seeded, logged-in session).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an app-wide confirmation dialog host for in-app prompts.
  * Added optional confirmation prompts before performing irreversible entity deletions.
  * Added an option to show or skip confirmation prompts for assignment/un-assignment toggle actions.

* **Bug Fixes**
  * Improved delete and toggle flows so actions only proceed after user confirmation when prompting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->