### PR TITLE
fix: destroy DataSource on error paths in migration CLI and DatabaseModule

### DIFF
--- a/apps/server-core/src/app/modules/database/module.ts
+++ b/apps/server-core/src/app/modules/database/module.ts
@@ -67,26 +67,28 @@ export class DatabaseModule implements IModule {
 
         const dataSource = new DataSource(options);
 
-        await dataSource.initialize();
-
-        // Subscribers must be pushed after initialize(), because
-        // initialize() overwrites dataSource.subscribers from options.
-        this.registerSubscribers(dataSource, container);
-
         try {
+            await dataSource.initialize();
+
+            // Subscribers must be pushed after initialize(), because
+            // initialize() overwrites dataSource.subscribers from options.
+            this.registerSubscribers(dataSource, container);
+
             setDataSource(dataSource);
 
             if (!check.schema) {
                 await synchronizeDatabaseSchema(dataSource);
             }
+
+            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
+
+            registerRepositories(container, dataSource);
         } catch (e) {
-            await dataSource.destroy();
+            if (dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
             throw e;
         }
-
-        container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
-
-        registerRepositories(container, dataSource);
     }
 
     async teardown(container: IContainer): Promise<void> {

--- a/apps/server-core/src/cli/commands/migration.ts
+++ b/apps/server-core/src/cli/commands/migration.ts
@@ -79,9 +79,9 @@ export function defineCLIMigrationCommand() {
                     ...options,
                     logging: ['error', 'schema', 'migration'],
                 });
-                await dataSource.initialize();
-
                 try {
+                    await dataSource.initialize();
+
                     if (context.args.operation === MigrationOperation.REVERT) {
                         await dataSource.undoLastMigration();
                     } else if (context.args.operation === MigrationOperation.STATUS) {
@@ -90,7 +90,9 @@ export function defineCLIMigrationCommand() {
                         await dataSource.runMigrations();
                     }
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
 
                 process.exit(0);
@@ -128,9 +130,10 @@ export function defineCLIMigrationCommand() {
                 await createDatabase({ options: dataSourceOptions, synchronize: false });
 
                 const dataSource = new DataSource(dataSourceOptions);
-                await dataSource.initialize();
 
                 try {
+                    await dataSource.initialize();
+
                     await dataSource.runMigrations();
 
                     await generateMigration({
@@ -141,7 +144,9 @@ export function defineCLIMigrationCommand() {
                         prettify: true,
                     });
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
             }
 

--- a/apps/server-core/src/cli/commands/migration.ts
+++ b/apps/server-core/src/cli/commands/migration.ts
@@ -81,15 +81,17 @@ export function defineCLIMigrationCommand() {
                 });
                 await dataSource.initialize();
 
-                if (context.args.operation === MigrationOperation.REVERT) {
-                    await dataSource.undoLastMigration();
-                } else if (context.args.operation === MigrationOperation.STATUS) {
-                    await dataSource.showMigrations();
-                } else {
-                    await dataSource.runMigrations();
+                try {
+                    if (context.args.operation === MigrationOperation.REVERT) {
+                        await dataSource.undoLastMigration();
+                    } else if (context.args.operation === MigrationOperation.STATUS) {
+                        await dataSource.showMigrations();
+                    } else {
+                        await dataSource.runMigrations();
+                    }
+                } finally {
+                    await dataSource.destroy();
                 }
-
-                await dataSource.destroy();
 
                 process.exit(0);
             }
@@ -127,15 +129,20 @@ export function defineCLIMigrationCommand() {
 
                 const dataSource = new DataSource(dataSourceOptions);
                 await dataSource.initialize();
-                await dataSource.runMigrations();
 
-                await generateMigration({
-                    dataSource,
-                    name: 'Default',
-                    directoryPath,
-                    timestamp,
-                    prettify: true,
-                });
+                try {
+                    await dataSource.runMigrations();
+
+                    await generateMigration({
+                        dataSource,
+                        name: 'Default',
+                        directoryPath,
+                        timestamp,
+                        prettify: true,
+                    });
+                } finally {
+                    await dataSource.destroy();
+                }
             }
 
             process.exit(0);

--- a/apps/server-messenger/src/app/modules/database/module.ts
+++ b/apps/server-messenger/src/app/modules/database/module.ts
@@ -39,22 +39,25 @@ export class DatabaseModule implements IModule {
         }
 
         const dataSource = new DataSource(options);
-        await dataSource.initialize();
 
         try {
+            await dataSource.initialize();
+
             setDataSource(dataSource);
 
             if (!check.schema) {
                 await synchronizeDatabaseSchema(dataSource);
             }
+
+            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
+
+            registerRepositories(container, dataSource);
         } catch (e) {
-            await dataSource.destroy();
+            if (dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
             throw e;
         }
-
-        container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
-
-        registerRepositories(container, dataSource);
     }
 
     async teardown(container: IContainer): Promise<void> {

--- a/apps/server-messenger/src/cli/commands/migration.ts
+++ b/apps/server-messenger/src/cli/commands/migration.ts
@@ -79,9 +79,9 @@ export function defineCLIMigrationCommand() {
                     ...options,
                     logging: ['error', 'schema', 'migration'],
                 });
-                await dataSource.initialize();
-
                 try {
+                    await dataSource.initialize();
+
                     if (context.args.operation === MigrationOperation.REVERT) {
                         await dataSource.undoLastMigration();
                     } else if (context.args.operation === MigrationOperation.STATUS) {
@@ -90,7 +90,9 @@ export function defineCLIMigrationCommand() {
                         await dataSource.runMigrations();
                     }
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
 
                 process.exit(0);
@@ -128,9 +130,10 @@ export function defineCLIMigrationCommand() {
                 await createDatabase({ options: dataSourceOptions, synchronize: false });
 
                 const dataSource = new DataSource(dataSourceOptions);
-                await dataSource.initialize();
 
                 try {
+                    await dataSource.initialize();
+
                     await dataSource.runMigrations();
 
                     await generateMigration({
@@ -141,7 +144,9 @@ export function defineCLIMigrationCommand() {
                         prettify: true,
                     });
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
             }
 

--- a/apps/server-messenger/src/cli/commands/migration.ts
+++ b/apps/server-messenger/src/cli/commands/migration.ts
@@ -81,15 +81,17 @@ export function defineCLIMigrationCommand() {
                 });
                 await dataSource.initialize();
 
-                if (context.args.operation === MigrationOperation.REVERT) {
-                    await dataSource.undoLastMigration();
-                } else if (context.args.operation === MigrationOperation.STATUS) {
-                    await dataSource.showMigrations();
-                } else {
-                    await dataSource.runMigrations();
+                try {
+                    if (context.args.operation === MigrationOperation.REVERT) {
+                        await dataSource.undoLastMigration();
+                    } else if (context.args.operation === MigrationOperation.STATUS) {
+                        await dataSource.showMigrations();
+                    } else {
+                        await dataSource.runMigrations();
+                    }
+                } finally {
+                    await dataSource.destroy();
                 }
-
-                await dataSource.destroy();
 
                 process.exit(0);
             }
@@ -127,15 +129,20 @@ export function defineCLIMigrationCommand() {
 
                 const dataSource = new DataSource(dataSourceOptions);
                 await dataSource.initialize();
-                await dataSource.runMigrations();
 
-                await generateMigration({
-                    dataSource,
-                    name: 'Default',
-                    directoryPath,
-                    timestamp,
-                    prettify: true,
-                });
+                try {
+                    await dataSource.runMigrations();
+
+                    await generateMigration({
+                        dataSource,
+                        name: 'Default',
+                        directoryPath,
+                        timestamp,
+                        prettify: true,
+                    });
+                } finally {
+                    await dataSource.destroy();
+                }
             }
 
             process.exit(0);

--- a/apps/server-storage/src/app/modules/database/module.ts
+++ b/apps/server-storage/src/app/modules/database/module.ts
@@ -46,38 +46,41 @@ export class DatabaseModule implements IModule {
         }
 
         const dataSource = new DataSource(options);
-        await dataSource.initialize();
-
-        // Subscribers must be pushed after initialize(), because
-        // initialize() overwrites dataSource.subscribers from options.
-        const subscribers = [
-            new BucketSubscriber(),
-            new BucketFileSubscriber(),
-        ];
-
-        const publisherResult = container.tryResolve(EntityEventPublisherInjectionKey);
-        if (publisherResult.success) {
-            for (const subscriber of subscribers) {
-                subscriber.setPublisher(publisherResult.data);
-            }
-        }
-
-        dataSource.subscribers.push(...subscribers);
 
         try {
+            await dataSource.initialize();
+
+            // Subscribers must be pushed after initialize(), because
+            // initialize() overwrites dataSource.subscribers from options.
+            const subscribers = [
+                new BucketSubscriber(),
+                new BucketFileSubscriber(),
+            ];
+
+            const publisherResult = container.tryResolve(EntityEventPublisherInjectionKey);
+            if (publisherResult.success) {
+                for (const subscriber of subscribers) {
+                    subscriber.setPublisher(publisherResult.data);
+                }
+            }
+
+            dataSource.subscribers.push(...subscribers);
+
             setDataSource(dataSource);
 
             if (!check.schema) {
                 await synchronizeDatabaseSchema(dataSource);
             }
+
+            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
+
+            registerRepositories(container, dataSource);
         } catch (e) {
-            await dataSource.destroy();
+            if (dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
             throw e;
         }
-
-        container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
-
-        registerRepositories(container, dataSource);
     }
 
     async teardown(container: IContainer): Promise<void> {

--- a/apps/server-storage/src/cli/commands/migration.ts
+++ b/apps/server-storage/src/cli/commands/migration.ts
@@ -79,9 +79,9 @@ export function defineCLIMigrationCommand() {
                     ...options,
                     logging: ['error', 'schema', 'migration'],
                 });
-                await dataSource.initialize();
-
                 try {
+                    await dataSource.initialize();
+
                     if (context.args.operation === MigrationOperation.REVERT) {
                         await dataSource.undoLastMigration();
                     } else if (context.args.operation === MigrationOperation.STATUS) {
@@ -90,7 +90,9 @@ export function defineCLIMigrationCommand() {
                         await dataSource.runMigrations();
                     }
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
 
                 process.exit(0);
@@ -128,9 +130,10 @@ export function defineCLIMigrationCommand() {
                 await createDatabase({ options: dataSourceOptions, synchronize: false });
 
                 const dataSource = new DataSource(dataSourceOptions);
-                await dataSource.initialize();
 
                 try {
+                    await dataSource.initialize();
+
                     await dataSource.runMigrations();
 
                     await generateMigration({
@@ -141,7 +144,9 @@ export function defineCLIMigrationCommand() {
                         prettify: true,
                     });
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
             }
 

--- a/apps/server-storage/src/cli/commands/migration.ts
+++ b/apps/server-storage/src/cli/commands/migration.ts
@@ -81,15 +81,17 @@ export function defineCLIMigrationCommand() {
                 });
                 await dataSource.initialize();
 
-                if (context.args.operation === MigrationOperation.REVERT) {
-                    await dataSource.undoLastMigration();
-                } else if (context.args.operation === MigrationOperation.STATUS) {
-                    await dataSource.showMigrations();
-                } else {
-                    await dataSource.runMigrations();
+                try {
+                    if (context.args.operation === MigrationOperation.REVERT) {
+                        await dataSource.undoLastMigration();
+                    } else if (context.args.operation === MigrationOperation.STATUS) {
+                        await dataSource.showMigrations();
+                    } else {
+                        await dataSource.runMigrations();
+                    }
+                } finally {
+                    await dataSource.destroy();
                 }
-
-                await dataSource.destroy();
 
                 process.exit(0);
             }
@@ -127,15 +129,20 @@ export function defineCLIMigrationCommand() {
 
                 const dataSource = new DataSource(dataSourceOptions);
                 await dataSource.initialize();
-                await dataSource.runMigrations();
 
-                await generateMigration({
-                    dataSource,
-                    name: 'Default',
-                    directoryPath,
-                    timestamp,
-                    prettify: true,
-                });
+                try {
+                    await dataSource.runMigrations();
+
+                    await generateMigration({
+                        dataSource,
+                        name: 'Default',
+                        directoryPath,
+                        timestamp,
+                        prettify: true,
+                    });
+                } finally {
+                    await dataSource.destroy();
+                }
             }
 
             process.exit(0);

--- a/apps/server-telemetry/src/app/modules/database/module.ts
+++ b/apps/server-telemetry/src/app/modules/database/module.ts
@@ -45,37 +45,40 @@ export class DatabaseModule implements IModule {
         }
 
         const dataSource = new DataSource(options);
-        await dataSource.initialize();
-
-        // Subscribers must be pushed after initialize(), because
-        // initialize() overwrites dataSource.subscribers from options.
-        const subscribers = [
-            new EventSubscriber(),
-        ];
-
-        const publisherResult = container.tryResolve(EntityEventPublisherInjectionKey);
-        if (publisherResult.success) {
-            for (const subscriber of subscribers) {
-                subscriber.setPublisher(publisherResult.data);
-            }
-        }
-
-        dataSource.subscribers.push(...subscribers);
 
         try {
+            await dataSource.initialize();
+
+            // Subscribers must be pushed after initialize(), because
+            // initialize() overwrites dataSource.subscribers from options.
+            const subscribers = [
+                new EventSubscriber(),
+            ];
+
+            const publisherResult = container.tryResolve(EntityEventPublisherInjectionKey);
+            if (publisherResult.success) {
+                for (const subscriber of subscribers) {
+                    subscriber.setPublisher(publisherResult.data);
+                }
+            }
+
+            dataSource.subscribers.push(...subscribers);
+
             setDataSource(dataSource);
 
             if (!check.schema) {
                 await synchronizeDatabaseSchema(dataSource);
             }
+
+            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
+
+            registerRepositories(container, dataSource);
         } catch (e) {
-            await dataSource.destroy();
+            if (dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
             throw e;
         }
-
-        container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
-
-        registerRepositories(container, dataSource);
     }
 
     async teardown(container: IContainer): Promise<void> {

--- a/apps/server-telemetry/src/cli/commands/migration.ts
+++ b/apps/server-telemetry/src/cli/commands/migration.ts
@@ -77,15 +77,17 @@ export function defineCLIMigrationCommand() {
                 });
                 await dataSource.initialize();
 
-                if (context.args.operation === MigrationOperation.REVERT) {
-                    await dataSource.undoLastMigration();
-                } else if (context.args.operation === MigrationOperation.STATUS) {
-                    await dataSource.showMigrations();
-                } else {
-                    await dataSource.runMigrations();
+                try {
+                    if (context.args.operation === MigrationOperation.REVERT) {
+                        await dataSource.undoLastMigration();
+                    } else if (context.args.operation === MigrationOperation.STATUS) {
+                        await dataSource.showMigrations();
+                    } else {
+                        await dataSource.runMigrations();
+                    }
+                } finally {
+                    await dataSource.destroy();
                 }
-
-                await dataSource.destroy();
 
                 process.exit(0);
             }
@@ -121,15 +123,20 @@ export function defineCLIMigrationCommand() {
 
                 const dataSource = new DataSource(dataSourceOptions);
                 await dataSource.initialize();
-                await dataSource.runMigrations();
 
-                await generateMigration({
-                    dataSource,
-                    name: 'Default',
-                    directoryPath,
-                    timestamp,
-                    prettify: true,
-                });
+                try {
+                    await dataSource.runMigrations();
+
+                    await generateMigration({
+                        dataSource,
+                        name: 'Default',
+                        directoryPath,
+                        timestamp,
+                        prettify: true,
+                    });
+                } finally {
+                    await dataSource.destroy();
+                }
             }
 
             process.exit(0);

--- a/apps/server-telemetry/src/cli/commands/migration.ts
+++ b/apps/server-telemetry/src/cli/commands/migration.ts
@@ -75,9 +75,9 @@ export function defineCLIMigrationCommand() {
                     ...options,
                     logging: ['error', 'schema', 'migration'],
                 });
-                await dataSource.initialize();
-
                 try {
+                    await dataSource.initialize();
+
                     if (context.args.operation === MigrationOperation.REVERT) {
                         await dataSource.undoLastMigration();
                     } else if (context.args.operation === MigrationOperation.STATUS) {
@@ -86,7 +86,9 @@ export function defineCLIMigrationCommand() {
                         await dataSource.runMigrations();
                     }
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
 
                 process.exit(0);
@@ -122,9 +124,10 @@ export function defineCLIMigrationCommand() {
                 await createDatabase({ options: dataSourceOptions, synchronize: false });
 
                 const dataSource = new DataSource(dataSourceOptions);
-                await dataSource.initialize();
 
                 try {
+                    await dataSource.initialize();
+
                     await dataSource.runMigrations();
 
                     await generateMigration({
@@ -135,7 +138,9 @@ export function defineCLIMigrationCommand() {
                         prettify: true,
                     });
                 } finally {
-                    await dataSource.destroy();
+                    if (dataSource.isInitialized) {
+                        await dataSource.destroy();
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

The migration CLI commands and `DatabaseModule.setup()` only destroyed the `DataSource` on the **success** path. If `initialize()`, `runMigrations()`, `undoLastMigration()`, `generateMigration()`, `synchronizeDatabaseSchema()` or the DI registration threw, the connection pool was leaked — and for the short-lived CLI, the leftover active handles could keep the event loop alive and hang the process. The migration `generate` loop never destroyed the `DataSource` at all.

This is a **shared pattern across services** (`server-core`, `server-storage`, `server-telemetry`, `server-messenger`), so the fix is applied to all four.

## Changes

- **Migration CLI** (`cli/commands/migration.ts`, all four services)
  - `run` / `revert` / `status`: wrapped the operation in `try { … } finally { await dataSource.destroy() }`.
  - `generate` loop: same `try/finally` guard — this path previously **never** destroyed the `DataSource`, leaking one pool per connection.
  - Mirrors authup's already-fixed shape (`initialize()` outside the `try`, `destroy()` in `finally`).
- **`DatabaseModule.setup()`** (all four services)
  - Widened the existing guard to cover `initialize()`, subscriber registration, `container.register(DataSource)` and `registerRepositories()` — everything after construction.
  - Destroys only when `dataSource.isInitialized` (so a failed `initialize()` doesn't raise a secondary "not connected" error), then re-throws. Uses `catch`+rethrow rather than `finally`, since the `DataSource` must stay alive on the success path.

## Verification

- `eslint` on all 8 changed files — clean.
- `nx build` for all four services (bundle + `tsc --emitDeclarationOnly` typecheck) — pass.

## Notes

The same underlying pattern was reported upstream and filed as a tailored issue in authup — authup/authup#3179 (authup's migration CLI is already hardened; only its `DatabaseModule.setup()` gap remains).

Closes #1716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during database startup by ensuring partial failures are cleaned up properly.
  * Migration commands now always close resources, even if a migration action or generation step fails.
  * Reduced the chance of leftover database connections or inconsistent state when setup or migration operations error out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->