### PR TITLE
fix: render correct registry host for node registry credentials

### DIFF
--- a/apps/server-core/src/app/modules/registry/adapter.ts
+++ b/apps/server-core/src/app/modules/registry/adapter.ts
@@ -26,9 +26,17 @@ export class RegistryManagerAdapter implements IRegistryManager {
     }
 
     async findDefaultRegistryId(): Promise<string | null> {
-        const registries = await this.registryRepository.find({ take: 1 });
-        const [registry] = registries;
-        return registry?.id ?? null;
+        // Only auto-assign a registry when the choice is unambiguous. There is no
+        // designated "default" registry, so with more than one configured, picking
+        // an arbitrary "first" row would provision the node against the wrong
+        // registry — later surfacing the wrong host in its credentials. When the
+        // choice is ambiguous, require an explicit registry selection instead.
+        const [registries, total] = await this.registryRepository.findAndCount({ take: 2 });
+        if (total !== 1) {
+            return null;
+        }
+
+        return registries[0].id;
     }
 
     async createProject(data: Partial<RegistryProject>): Promise<RegistryProject> {

--- a/apps/server-core/src/core/entities/node/service.ts
+++ b/apps/server-core/src/core/entities/node/service.ts
@@ -175,6 +175,17 @@ export class NodeService extends AbstractEntityService implements INodeService {
             registryProject = await this.registryManager.findProject(entity.registry_project_id) ?? undefined;
         }
 
+        // A registry project lives inside a single registry, so when the node is
+        // re-assigned to a different registry the existing project can no longer
+        // serve it. Tear it down and provision a fresh one on the new registry —
+        // otherwise the node keeps resolving its credentials (and host) from the
+        // old registry.
+        if (registryProject && registryProject.registry_id !== entity.registry_id) {
+            await this.registryManager.unlinkProject(registryProject);
+            await this.registryManager.removeProject(registryProject);
+            registryProject = undefined;
+        }
+
         if (registryProject) {
             if (registryProject.external_name !== externalName) {
                 registryProject.external_name = externalName;

--- a/apps/server-core/test/unit/core/entities/node/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/node/service.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Node } from '@privateaim/core-kit';
+import type { Node, RegistryProject } from '@privateaim/core-kit';
+import { RegistryProjectType } from '@privateaim/core-kit';
 import { EntityNotFoundError, PermissionDeniedError } from '@privateaim/errors';
 import {
     beforeEach,
@@ -42,6 +43,27 @@ function createTestNode(overrides?: Partial<Node>): Node {
         updated_at: new Date(),
         ...overrides,
     } as Node;
+}
+
+function createTestRegistryProject(overrides?: Partial<RegistryProject>): RegistryProject {
+    return {
+        id: randomUUID(),
+        name: 'test-project',
+        type: RegistryProjectType.NODE,
+        public: false,
+        external_name: 'extname',
+        external_id: null,
+        account_id: null,
+        account_name: null,
+        account_secret: null,
+        webhook_name: null,
+        webhook_exists: null,
+        registry_id: randomUUID(),
+        realm_id: 'realm-1',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        ...overrides,
+    } as RegistryProject;
 }
 
 describe('NodeService', () => {
@@ -180,6 +202,74 @@ describe('NodeService', () => {
             await expect(
                 service.update(node.id, { name: 'updated-node' }, createNonMasterRealmActor('realm-1')),
             ).rejects.toThrow(PermissionDeniedError);
+        });
+
+        it('should re-provision the registry project when re-assigned to a different registry', async () => {
+            const registryId = randomUUID();
+            const nextRegistryId = randomUUID();
+
+            const registryProject = createTestRegistryProject({
+                registry_id: registryId,
+                external_name: 'extname',
+            });
+            registryManager.seedProject(registryProject);
+
+            const node = createTestNode({
+                realm_id: 'realm-1',
+                registry_id: registryId,
+                registry_project_id: registryProject.id,
+                external_name: 'extname',
+            });
+            repository.seed(node);
+
+            const result = await service.update(
+                node.id,
+                { registry_id: nextRegistryId },
+                createMasterRealmActor(),
+            );
+
+            // The stale project (on the old registry) is torn down ...
+            expect(registryManager.getUnlinkCalls()).toHaveLength(1);
+            expect(registryManager.getUnlinkCalls()[0].id).toBe(registryProject.id);
+
+            // ... and a fresh project is provisioned on the new registry.
+            const projects = registryManager.getProjects();
+            expect(projects).toHaveLength(1);
+            expect(projects[0].id).not.toBe(registryProject.id);
+            expect(projects[0].registry_id).toBe(nextRegistryId);
+
+            // The node now points at the new project (so credentials resolve the
+            // new registry's host, not the old one).
+            expect(result.registry_project_id).toBe(projects[0].id);
+            expect(registryManager.getLinkCalls()).toContain(projects[0].id);
+        });
+
+        it('should keep the existing registry project when the registry is unchanged', async () => {
+            const registryId = randomUUID();
+
+            const registryProject = createTestRegistryProject({
+                registry_id: registryId,
+                external_name: 'extname',
+            });
+            registryManager.seedProject(registryProject);
+
+            const node = createTestNode({
+                realm_id: 'realm-1',
+                registry_id: registryId,
+                registry_project_id: registryProject.id,
+                external_name: 'extname',
+            });
+            repository.seed(node);
+
+            const result = await service.update(
+                node.id,
+                { name: 'renamed-node' },
+                createMasterRealmActor(),
+            );
+
+            expect(registryManager.getUnlinkCalls()).toHaveLength(0);
+            expect(registryManager.getProjects()).toHaveLength(1);
+            expect(result.registry_project_id).toBe(registryProject.id);
         });
     });
 

--- a/packages/client-vue/src/components/node/FNodeRegistryCredentials.vue
+++ b/packages/client-vue/src/components/node/FNodeRegistryCredentials.vue
@@ -44,14 +44,20 @@ export default defineComponent({
         const busy = ref(false);
         const loaded = ref(false);
 
+        // Monotonic token identifying the most recent load(). The parent reuses
+        // this component across node ids, so a slow in-flight request for a
+        // previous node must never overwrite the credentials of the node that is
+        // shown now — otherwise a node renders another node's registry host
+        // (only noticeable when the nodes belong to registries with different
+        // hosts). Only the response whose token still matches is applied.
+        let loadToken = 0;
+
         const load = async () => {
-            if (busy.value) {
-                return;
-            }
+            const token = ++loadToken;
+            const nodeId = props.entity.id;
 
             // Reset so a previous node's credentials never linger while the
-            // current one is (re)loaded — important because the parent reuses
-            // this component across node ids.
+            // current one is (re)loaded.
             revealed.value = false;
             host.value = null;
             externalName.value = null;
@@ -59,22 +65,33 @@ export default defineComponent({
             accountSecret.value = null;
 
             if (!props.entity.registry_project_id) {
+                busy.value = false;
                 loaded.value = true;
                 return;
             }
 
             busy.value = true;
+            loaded.value = false;
             try {
-                const credentials = await httpClient.node.getRegistryCredentials(props.entity.id);
+                const credentials = await httpClient.node.getRegistryCredentials(nodeId);
+                if (token !== loadToken) {
+                    // A newer load() superseded this request — drop the result.
+                    return;
+                }
+
                 host.value = credentials.host;
                 externalName.value = credentials.external_name;
                 accountName.value = credentials.account_name;
                 accountSecret.value = credentials.account_secret;
             } catch (e) {
-                emit('failed', e);
+                if (token === loadToken) {
+                    emit('failed', e);
+                }
             } finally {
-                busy.value = false;
-                loaded.value = true;
+                if (token === loadToken) {
+                    busy.value = false;
+                    loaded.value = true;
+                }
             }
         };
 


### PR DESCRIPTION
## Problem

In the node registry credentials panel (`FNodeRegistryCredentials`), a **wrong host name** was rendered when one of several registries was assigned. The symptom only appeared with **multiple registries that have different hosts** — with a single registry every node's host is identical, so the defect was invisible.

Root causes were both a client-side render race and two server-side data bugs that bound a node to the wrong registry.

## Changes

### `client-vue` — stale-response race in the credentials panel
The parent reuses a single `FNodeRegistryCredentials` instance across node ids (as the code's own comment notes). `load()`:
- dropped the reload entirely via `if (busy.value) return;` when switching nodes while a request was in flight, and
- applied responses unconditionally (last-write-wins), so a slow response for a previous node could overwrite the current one.

Both left a node showing another node's registry host. Fixed by sequencing loads with a monotonic token — only the latest node's response is applied — and removing the drop-on-busy guard so a node switch always reloads.

### `server-core` — node bound to the wrong registry
- **`RegistryManagerAdapter.findDefaultRegistryId()`** grabbed an arbitrary first row via `find({ take: 1 })`. There is no designated default registry, so with more than one configured it now returns `null` (requiring an explicit selection) and only auto-assigns when exactly one registry exists.
- **`NodeService.syncRegistryProject()`** reused the existing project when a node was re-assigned to a different registry, only updating `external_name` and never re-pointing `registry_id` — so credentials kept resolving the old registry's host. It now tears down the stale project and provisions a fresh one on the new registry.

## Tests

Added `NodeService.update` unit tests:
- re-provisions the registry project (unlink old + link new on the new registry, node points at the new project) when re-assigned to a different registry;
- keeps the existing project when the registry is unchanged.

`npx vitest run --root apps/server-core test/unit/core/entities/node test/unit/core/services/registry-credential` → 31 passed. ESLint clean on all changed files.