### PR TITLE
refactor(server-core): resolve relation query keys via schemaMapping

### DIFF
--- a/apps/server-core/src/core/entities/analysis-bucket-file/schema.ts
+++ b/apps/server-core/src/core/entities/analysis-bucket-file/schema.ts
@@ -20,7 +20,7 @@ export const analysisBucketFileSchema = defineSchema({
         default: ['id', 'path', 'root', 'bucket_id', 'bucket_file_id', 'client_id', 'robot_id', 'user_id', 'realm_id', 'analysis_id', 'analysis_bucket_id', 'created_at', 'updated_at'],
         allowed: ['id', 'path', 'root', 'bucket_id', 'bucket_file_id', 'client_id', 'robot_id', 'user_id', 'realm_id', 'analysis_id', 'analysis_bucket_id', 'created_at', 'updated_at'],
     },
-    filters: { allowed: ['path', 'root', 'analysis_bucket_id', 'analysis_id', 'analysis.id', 'analysis.name', 'analysis.display_name', 'analysis_bucket.type'] },
+    filters: { allowed: ['path', 'root', 'analysis_bucket_id', 'analysis_id'] },
     relations: { allowed: ['analysis', 'analysis_bucket'] },
     sort: { allowed: ['path', 'created_at', 'updated_at'] },
     pagination: { maxLimit: 50 },

--- a/apps/server-core/src/core/entities/analysis-bucket/schema.ts
+++ b/apps/server-core/src/core/entities/analysis-bucket/schema.ts
@@ -17,7 +17,7 @@ export const analysisBucketSchema = defineSchema({
         default: ['id', 'type', 'bucket_id', 'analysis_id', 'realm_id', 'created_at', 'updated_at'],
         allowed: ['id', 'type', 'bucket_id', 'analysis_id', 'realm_id', 'created_at', 'updated_at'],
     },
-    filters: { allowed: ['analysis_id', 'type', 'analysis.id', 'analysis.name', 'analysis.display_name'] },
+    filters: { allowed: ['analysis_id', 'type'] },
     relations: { allowed: ['analysis'] },
     sort: { allowed: ['type', 'created_at', 'updated_at'] },
     pagination: { maxLimit: 50 },

--- a/apps/server-core/src/core/entities/analysis-node/schema.ts
+++ b/apps/server-core/src/core/entities/analysis-node/schema.ts
@@ -16,9 +16,9 @@ const schemaMapping = {
 export const analysisNodeSchema = defineSchema({
     name: DomainType.ANALYSIS_NODE,
     strict: true,
-    filters: { allowed: ['execution_status', 'approval_status', 'analysis_id', 'analysis_realm_id', 'analysis.id', 'analysis.name', 'analysis.display_name', 'analysis.project_id', 'node_id', 'node_realm_id', 'node.name', 'node.realm_id'] },
+    filters: { allowed: ['execution_status', 'approval_status', 'analysis_id', 'analysis_realm_id', 'node_id', 'node_realm_id'] },
     relations: { allowed: ['node', 'analysis'] },
-    sort: { allowed: ['created_at', 'updated_at', 'analysis.name', 'analysis.display_name', 'analysis.created_at', 'analysis.updated_at', 'node.name', 'node.created_at', 'node.updated_at'] },
+    sort: { allowed: ['created_at', 'updated_at'] },
     pagination: { maxLimit: 50 },
     schemaMapping,
 });

--- a/apps/server-core/src/core/entities/analysis/schema.ts
+++ b/apps/server-core/src/core/entities/analysis/schema.ts
@@ -23,7 +23,7 @@ export const analysisSchema = defineSchema<Analysis>({
     },
     filters: { allowed: ['id', 'name', 'display_name', 'description', 'project_id', 'realm_id', 'build_status', 'execution_status', 'configuration_locked'] },
     relations: { allowed: ['project', 'master_image'] },
-    sort: { allowed: ['created_at', 'updated_at'], default: { updated_at: 'DESC' } },
+    sort: { allowed: ['name', 'display_name', 'created_at', 'updated_at'], default: { updated_at: 'DESC' } },
     pagination: { maxLimit: 50 },
     schemaMapping,
 });

--- a/apps/server-core/src/core/entities/project-node/schema.ts
+++ b/apps/server-core/src/core/entities/project-node/schema.ts
@@ -16,9 +16,9 @@ const schemaMapping = {
 export const projectNodeSchema = defineSchema({
     name: DomainType.PROJECT_NODE,
     strict: true,
-    filters: { allowed: ['project_realm_id', 'project_id', 'project.id', 'project.name', 'project.display_name', 'node_realm_id', 'node_id', 'node.name'] },
+    filters: { allowed: ['project_realm_id', 'project_id', 'node_realm_id', 'node_id'] },
     relations: { allowed: ['node', 'project'] },
-    sort: { allowed: ['created_at', 'updated_at', 'project.name', 'project.display_name', 'project.created_at', 'project.updated_at', 'node.name', 'node.created_at', 'node.updated_at'] },
+    sort: { allowed: ['created_at', 'updated_at'] },
     pagination: { maxLimit: 50 },
     schemaMapping,
 });

--- a/apps/server-core/src/core/entities/project/schema.ts
+++ b/apps/server-core/src/core/entities/project/schema.ts
@@ -20,7 +20,7 @@ export const projectSchema = defineSchema<Project>({
     },
     filters: { allowed: ['id', 'name', 'display_name', 'realm_id', 'user_id'] },
     relations: { allowed: ['master_image'] },
-    sort: { allowed: ['id', 'updated_at', 'created_at'] },
+    sort: { allowed: ['id', 'name', 'display_name', 'updated_at', 'created_at'] },
     pagination: { maxLimit: 50 },
     schemaMapping,
 });

--- a/apps/server-core/test/unit/core/query/relation-schema-resolution.spec.ts
+++ b/apps/server-core/test/unit/core/query/relation-schema-resolution.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition, IFilters, IQuery } from '@rapiq/core';
+import { isFilters } from '@rapiq/core';
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { analysisNodeSchema } from '../../../../src/core/entities/analysis-node/schema.ts';
+import { projectNodeSchema } from '../../../../src/core/entities/project-node/schema.ts';
+import { decodeQuery } from '../../../../src/core/query/index.ts';
+
+// A junction schema (analysis-node, project-node) does not re-list the fields
+// of its related entities in its own filter/sort allow-lists. Instead it maps
+// each relation to the related schema via `schemaMapping`, and rapiq resolves a
+// dotted key (`analysis.name`) by descending into the related schema's own
+// allow-lists. These tests pin that resolution so the dotted entries stay gone.
+
+function filterFields(query: IQuery): string[] {
+    const out: string[] = [];
+    const walk = (group: IFilters) => {
+        for (const condition of group.value as ICondition[]) {
+            if (isFilters(condition)) {
+                walk(condition);
+                continue;
+            }
+            out.push((condition as { field: string }).field);
+        }
+    };
+    if (isFilters(query.filters)) {
+        walk(query.filters);
+    }
+    return out;
+}
+
+const sortNames = (query: IQuery): string[] => query.sorts.value.map((s) => s.name);
+
+describe('relation schema resolution', () => {
+    describe('analysis-node', () => {
+        it('resolves a related analysis filter through schemaMapping', () => {
+            const query = decodeQuery(
+                { filter: { 'analysis.name': 'foo' }, include: 'analysis' },
+                { schema: analysisNodeSchema },
+            );
+            expect(filterFields(query)).toContain('analysis.name');
+        });
+
+        it('resolves a related node filter through schemaMapping', () => {
+            const query = decodeQuery(
+                { filter: { 'node.name': 'bar' }, include: 'node' },
+                { schema: analysisNodeSchema },
+            );
+            expect(filterFields(query)).toContain('node.name');
+        });
+
+        it('resolves a related analysis sort through schemaMapping', () => {
+            const query = decodeQuery(
+                { sort: 'analysis.name', include: 'analysis' },
+                { schema: analysisNodeSchema },
+            );
+            expect(sortNames(query)).toContain('analysis.name');
+        });
+
+        it('drops a related filter the target schema does not allow', () => {
+            // `build_hash` is a column on analysis but not in analysisSchema.filters
+            // — the related schema, not the junction, governs what is filterable.
+            const query = decodeQuery(
+                { filter: { 'analysis.build_hash': 'x' }, include: 'analysis' },
+                { schema: analysisNodeSchema },
+            );
+            expect(filterFields(query)).not.toContain('analysis.build_hash');
+        });
+
+        it('still resolves the junction\'s own root filters', () => {
+            const query = decodeQuery(
+                { filter: { execution_status: 'running' } },
+                { schema: analysisNodeSchema },
+            );
+            expect(filterFields(query)).toContain('execution_status');
+        });
+    });
+
+    describe('project-node', () => {
+        it('resolves a related project sort through schemaMapping', () => {
+            const query = decodeQuery(
+                { sort: 'project.name', include: 'project' },
+                { schema: projectNodeSchema },
+            );
+            expect(sortNames(query)).toContain('project.name');
+        });
+
+        it('resolves a related project filter through schemaMapping', () => {
+            const query = decodeQuery(
+                { filter: { 'project.display_name': 'p' }, include: 'project' },
+                { schema: projectNodeSchema },
+            );
+            expect(filterFields(query)).toContain('project.display_name');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The junction query schemas — `analysis-node`, `project-node`, `analysis-bucket`, `analysis-bucket-file` — still hand-listed related-entity fields (`analysis.id`, `analysis.name`, `node.name`, `project.display_name`, …) in their own `filters`/`sort` allow-lists. These are leftovers from the mechanical v1 `applyQuery` port: rapiq v1 had no schema registry, so every relation path had to be enumerated locally.

rapiq v2 (landed on `master` via #1772) already resolves a dotted key by descending the relation through the owning schema's `schemaMapping` into the **related schema's own allow-lists** — exactly as documented in `core/query/module.ts` and as the authup blueprint does (zero dotted keys across its 21 entity schemas). So the dotted entries were pure redundancy.

## Changes

- **Drop every dotted `relation.field` entry** from the four junction schemas' `filters`/`sort` allow-lists; `schemaMapping` + `relations.allowed` now resolve them.
- **Widen `analysis` and `project` `sort.allowed`** with `name`/`display_name`. Because the related schema now governs what is sortable on it, this keeps the `analysis-node`/`project-node` relation sorts (`sort=analysis.name`, `sort=project.name`) working — and, consistently, lets the root `analysis`/`project` lists sort by name too (they previously could not, an asymmetry the v2 resolution model surfaced).
- **Add `test/unit/core/query/relation-schema-resolution.spec.ts`** — the relation-key resolution path had no prior coverage. It pins that nested filters/sorts resolve via `schemaMapping`, that a leaf the related schema disallows (`analysis.build_hash`) is dropped, and that root filters still work.

## Why the sort widening is required, not cosmetic

`sort=analysis.name` was previously accepted only because `analysisNodeSchema.sort` listed `analysis.name` explicitly. Once resolution defers to the related schema, `analysisSchema.sort` must itself allow `name`/`display_name` — otherwise the nested sort would be (correctly) rejected. The filter entries needed no such change: every dropped `analysis.*`/`node.*`/`project.*` filter leaf is already in the related schema's `filters.allowed`.

## Verification

- `nx test server-core` — **419 passed** (44 files), incl. 7 new resolution tests
- `tsc --noEmit` (build:types) — clean
- ESLint — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting by name and display name for analyses and projects.

* **Improvements**
  * Tightened filtering and sorting options for analysis and project relationships.
  * Retained support for valid relationship-based query fields while excluding unsupported fields.

* **Tests**
  * Added coverage to verify relationship filters and sorting resolve correctly and reject invalid fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->