### PR TITLE
fix: stop registry deletion from destroying nodes and analyses; fix registry projects sidebar

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -94,6 +94,50 @@ export const analysisSchema = z.object({
 });
 ```
 
+## Database Migrations
+
+Migrations live in `apps/<service>/src/adapters/database/migrations/{mysql,postgres}/`.
+SQLite never runs them — the options builder wires `migrations: []` for
+`better-sqlite3`, so boot (and the test suite) falls back to `dataSource.synchronize()`
+from the entity classes.
+
+Adopted from authup — see [authup-conventions.md](references/authup-conventions.md#database-migrations).
+
+- **One named migration per feature.** Each feature/PR adds its migration in
+  **both** dialects, with a descriptive class/file name and a doc-comment header
+  explaining *why* the change is being made.
+- **Nothing a migration does may be invisible from its name.** Bundling several
+  changes into one file is allowed, but then the file name and the doc comment
+  must name *every* one of them (e.g.
+  `1784000000000-RegistryFkSetNullAndRenameAnalysis.ts`). The failure mode this
+  prevents is real: `AddDisplayName1780300000000` silently renamed
+  `analysis_entity` → `analysis`, and that hidden rename has since misled every
+  later migration that referenced the table by its old name. A rename in
+  particular must never hide behind an unrelated migration name.
+- **Consolidation happens at release time, not merge time.** A release window's
+  migrations may be squashed into one file per dialect as a deliberate last step
+  before the release PR merges (keeping the earliest timestamp so ordering against
+  the released chain holds). Shipping several named migrations in one release is fine.
+- **Released migrations are immutable.** Amend freely while the migration lives only
+  on its own unmerged branch; once it ships in a release, never touch it.
+- **Always verify with the round-trip** — `migration run` → `revert` × N → `run`,
+  against both MySQL and PostgreSQL. See [testing.md](testing.md#migration-tests).
+  Note that MySQL DDL is not transactional: a migration that fails halfway leaves
+  the schema partially altered, so a broken `up()` must be fixed against a fresh
+  database.
+- **FK delete rules**: cascade only when the child genuinely cannot exist without
+  the parent (`registry_projects.registry_id`). When the child is an independent
+  resource that merely *points at* the parent, use `ON DELETE SET NULL` so deleting
+  the parent detaches instead of destroying — `nodes.registry_id`,
+  `nodes.registry_project_id` and `analyses.registry_id` all had to be corrected
+  from cascade to set-null for this reason.
+
+### Table Naming
+
+Table names are **plural** and snake_case: `nodes`, `projects`, `registries`,
+`registry_projects`, `master_images`, `analyses`, `analysis_nodes`, `analysis_buckets`.
+Set them explicitly with `@Entity({ name: 'analyses' })` — there is no naming strategy.
+
 ## Logging
 
 Logs flow through Winston → `LoggerTransport` (`packages/server-telemetry-kit/src/services/logger/transport.ts`) → telemetry/VictoriaLogs, where every string/number/boolean key of the metadata object becomes a **queryable label**. UI views (e.g. the analysis log panel) filter by these labels — see `AnalysisLogController`, which queries `ref_type=analysis` + `ref_id=<id>`.

--- a/.agents/references/authup-conventions.md
+++ b/.agents/references/authup-conventions.md
@@ -33,6 +33,45 @@ This documents the conventions Hub should adopt as part of modernization (see Pl
 2. Barrel `index.ts` files re-export from `types.ts` and implementation modules
 3. No explanatory comments unless explicitly requested
 
+## Database Migrations
+
+Source: [`.agents/conventions.md` § Database Migrations](https://github.com/authup/authup/blob/master/.agents/conventions.md) (authup), verified 2026-07-26.
+
+**Authup pattern:**
+- **One named migration per feature.** Each feature/PR adds its own migration in both
+  dialects with a descriptive class/file name (`1784289540000-CamelCaseAttributes.ts`,
+  `1784460916000-RemoveRobots.ts`) and a doc-comment header explaining the change.
+- **Consolidation happens at release time, not merge time.** A release window's
+  migrations *may* be squashed into one file per dialect as a deliberate last step
+  before the release PR merges (keeping the earliest timestamp). Shipping several
+  named migrations in one release is fine.
+- **Released migrations are immutable.** A migration may be amended while it lives
+  only on its own unmerged branch; once released, never touch it.
+- After adding or amending a migration, run the round-trip: `migration run` →
+  `revert` × N → `run`.
+
+**Hub mapping:** same layout — `apps/<service>/src/adapters/database/migrations/{mysql,postgres}/`,
+same sqlite carve-out (`migrations: []`, boot falls back to `synchronize()`), and the
+same round-trip check is already documented in [testing.md](../testing.md#migration-tests)
+and run by the `tests-migrations` CI job. See
+[conventions.md § Database Migrations](../conventions.md#database-migrations).
+
+**Hub divergence:** hub allows several changes to share one migration file, where
+authup keeps them strictly one-per-feature until release-time squashing. Hub's
+constraint is instead that the file name and doc comment must name every change the
+migration performs, so nothing a migration does is invisible from its name.
+
+## Table Naming
+
+**Authup pattern:** every table is plural and prefixed — `auth_users`, `auth_roles`,
+`auth_scopes`, `auth_sessions`, `auth_role_permissions`, `auth_identity_provider_accounts`.
+No singular exceptions across ~20 tables.
+
+**Hub mapping:** Hub is unprefixed but otherwise matches — `nodes`, `projects`,
+`registries`, `registry_projects`, `master_images`, `analysis_nodes`, `analysis_buckets`.
+The analysis table was the sole singular outlier (`analysis_entity` → `analysis` →
+`analyses`, the last step by `RenameAnalysisTable1785000000000`).
+
 ## Configuration Naming
 
 | Pattern | Example |

--- a/.agents/references/authup-conventions.md
+++ b/.agents/references/authup-conventions.md
@@ -70,7 +70,7 @@ No singular exceptions across ~20 tables.
 **Hub mapping:** Hub is unprefixed but otherwise matches — `nodes`, `projects`,
 `registries`, `registry_projects`, `master_images`, `analysis_nodes`, `analysis_buckets`.
 The analysis table was the sole singular outlier (`analysis_entity` → `analysis` →
-`analyses`, the last step by `RenameAnalysisTable1785000000000`).
+`analyses`, the last step by `RegistryFkSetNullAndRenameAnalysis1784000000000`).
 
 ## Configuration Naming
 

--- a/apps/client-ui/pages/admin/nodes/[id]/registry.vue
+++ b/apps/client-ui/pages/admin/nodes/[id]/registry.vue
@@ -7,11 +7,19 @@
 <script lang="ts">
 import type { Node } from '@privateaim/core-kit';
 import type { PropType } from 'vue';
-import { FNodeRegistryCredentials, FNodeRegistryProject } from '@privateaim/client-vue';
+import {
+    FNodeRegistryConnection,
+    FNodeRegistryCredentials,
+    FNodeRegistryProject,
+} from '@privateaim/client-vue';
 import { defineNuxtComponent } from '#app';
 
 export default defineNuxtComponent({
-    components: { FNodeRegistryCredentials, FNodeRegistryProject },
+    components: {
+        FNodeRegistryConnection, 
+        FNodeRegistryCredentials, 
+        FNodeRegistryProject, 
+    },
     props: {
         entity: {
             type: Object as PropType<Node>,
@@ -40,18 +48,38 @@ export default defineNuxtComponent({
         v-if="entity"
         class="flex flex-col gap-4"
     >
-        <FNodeRegistryCredentials
+        <!--
+            The node ↔ registry assignment. Owns connect/disconnect: an update of
+            `registry_id` provisions or tears down the node's registry project
+            server-side. Previously this lived in the general node form.
+        -->
+        <FNodeRegistryConnection
             :entity="entity"
-            @failed="handleFailed"
-        />
-
-        <hr class="my-0">
-
-        <FNodeRegistryProject
-            :entity="entity"
-            :realm-id="entity.realm_id"
             @updated="handleUpdated"
             @failed="handleFailed"
         />
+
+        <template v-if="entity.registry_project_id">
+            <hr class="my-0">
+
+            <FNodeRegistryCredentials
+                :entity="entity"
+                @failed="handleFailed"
+            />
+
+            <hr class="my-0">
+
+            <!--
+                Secondary, repair-level action: (re)links the already-provisioned
+                registry project against the registry itself (Harbor project +
+                robot account) without touching the node's assignment.
+            -->
+            <FNodeRegistryProject
+                :entity="entity"
+                :realm-id="entity.realm_id"
+                @updated="handleUpdated"
+                @failed="handleFailed"
+            />
+        </template>
     </div>
 </template>

--- a/apps/client-ui/pages/admin/services/registry/[id].vue
+++ b/apps/client-ui/pages/admin/services/registry/[id].vue
@@ -52,20 +52,19 @@ export default defineComponent({
                     toast.show({ variant: 'success', body: 'The registry was successfully deleted.' });
                 }
 
-                return navigateTo('/admin/registries');
+                return navigateTo('/admin/services/registry');
             },
         });
 
         await manager.resolve({ query: { fields: ['+account_secret'] } });
 
         if (!manager.data.value) {
-            await navigateTo({ path: '/admin/services/registries' });
+            await navigateTo({ path: '/admin/services/registry' });
             throw createError({});
         }
 
         const tabs = computed<NavigationItem[]>(() => {
             const base = `/admin/services/registry/${manager.data.value?.id}`;
-            const projectsBase = `${base}/projects`;
 
             return [
                 {
@@ -94,21 +93,22 @@ export default defineComponent({
                         ] : []
                 ),
                 {
+                    // Leaf on purpose: this strip is a horizontal `variant="pills"`
+                    // segmented control, whose submenus render as an inline
+                    // `Collapsible` (`orientation` is unset ⇒ collapse mode). A
+                    // `children` array here would expand a vertical sub-list INSIDE
+                    // the pill strip and turn the segment into a non-navigable
+                    // `<button>` trigger. The overview/add sub-navigation lives in
+                    // `[id]/projects.vue` as its own vertical sidebar instead —
+                    // the same shape as `projects/[id]/analyses.vue`.
                     name: 'Projects',
                     icon: 'fa6-solid:diagram-project',
-                    url: projectsBase,
-                    children: [
-                        {
-                            name: 'overview',
-                            icon: 'fa6-solid:bars',
-                            url: projectsBase,
-                        },
-                        {
-                            name: 'add',
-                            icon: 'fa6-solid:plus',
-                            url: `${projectsBase}/add`,
-                        },
-                    ],
+                    url: `${base}/projects`,
+                    // Without this, `/projects/add` and `/projects/:id` only
+                    // score a prefix match — the same score the back arrow and
+                    // "General" get from their own prefixes — and the first
+                    // item wins the tie, lighting up the back arrow instead.
+                    activeMatch: `${base}/projects`,
                 },
             ];
         });

--- a/apps/client-ui/pages/admin/services/registry/[id]/projects.vue
+++ b/apps/client-ui/pages/admin/services/registry/[id]/projects.vue
@@ -6,9 +6,11 @@
   -->
 
 <script lang="ts">
+import type { Registry } from '@privateaim/core-kit';
 import { PermissionName } from '@privateaim/kit';
+import type { NavigationItem } from '@vuecs/navigation';
+import { computed, toRef } from 'vue';
 import type { PropType } from 'vue';
-import type { Realm } from '@authup/core-kit';
 import { definePageMeta } from '#imports';
 import { defineNuxtComponent } from '#app';
 import { LayoutKey, LayoutNavigationID } from '../../../../../config/layout';
@@ -16,11 +18,11 @@ import { LayoutKey, LayoutNavigationID } from '../../../../../config/layout';
 export default defineNuxtComponent({
     props: {
         entity: {
-            type: Object as PropType<Realm>,
+            type: Object as PropType<Registry>,
             required: true,
         },
     },
-    setup() {
+    setup(props) {
         definePageMeta({
             [LayoutKey.NAVIGATION_ID]: LayoutNavigationID.ADMIN,
             [LayoutKey.REQUIRED_LOGGED_IN]: true,
@@ -28,9 +30,41 @@ export default defineNuxtComponent({
                 PermissionName.REGISTRY_MANAGE,
             ],
         });
+
+        const entity = toRef(props, 'entity');
+
+        const tabs = computed<NavigationItem[]>(() => {
+            const base = `/admin/services/registry/${entity.value.id}/projects`;
+
+            return [
+                {
+                    name: 'overview',
+                    icon: 'fa6-solid:bars',
+                    url: base,
+                },
+                {
+                    name: 'add',
+                    icon: 'fa6-solid:plus',
+                    url: `${base}/add`,
+                },
+            ];
+        });
+
+        return { tabs };
     },
 });
 </script>
 <template>
-    <NuxtPage :entity="entity" />
+    <div class="content-wrapper">
+        <div class="content-sidebar flex-col">
+            <VCNavItems
+                :data="tabs"
+                variant="pills"
+                orientation="vertical"
+            />
+        </div>
+        <div class="content-container">
+            <NuxtPage :entity="entity" />
+        </div>
+    </div>
 </template>

--- a/apps/client-ui/pages/admin/services/registry/[id]/projects/[project_id].vue
+++ b/apps/client-ui/pages/admin/services/registry/[id]/projects/[project_id].vue
@@ -36,7 +36,9 @@ export default defineNuxtComponent({
         const manager = createEntityManager({
             type: `${DomainType.REGISTRY_PROJECT}`,
             props: {
-                entityId: route.params.id as string,
+                // `id` is the parent `[id]` segment (the registry); the project is
+                // the `[project_id]` segment of this route.
+                entityId: route.params.project_id as string,
                 queryFields: [
                     '+account_id',
                     '+account_name',
@@ -60,14 +62,14 @@ export default defineNuxtComponent({
                     toast.show({ variant: 'success', body: 'The project was successfully deleted.' });
                 }
 
-                return navigateTo(`/admin/registries/${props.entity.id}/projects`);
+                return navigateTo(`/admin/services/registry/${props.entity.id}/projects`);
             },
         });
 
         await manager.resolve();
 
         if (!manager.data.value) {
-            await navigateTo({ path: `/admin/registries/${route.params.id}/projects` });
+            await navigateTo({ path: `/admin/services/registry/${route.params.id}/projects` });
             throw createError({});
         }
 

--- a/apps/server-core-worker/src/app/components/analysis-builder/error.ts
+++ b/apps/server-core-worker/src/app/components/analysis-builder/error.ts
@@ -5,17 +5,34 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { AnalysisBuilderErrorCode } from '@privateaim/server-core-worker-kit';
+import { AnalysisBuilderErrorCode, ErrorCode } from '@privateaim/server-core-worker-kit';
 import type { ComponentErrorOptions } from '@privateaim/server-kit';
 import { BaseError } from '../error';
 
 export class BuilderError extends BaseError {
+    // Constructed directly rather than delegating to `super`: the base factories
+    // return a `BaseError`, so delegating produced an object that was not a
+    // `BuilderError` despite the annotation — and `registryNotFound` delegated to
+    // `super.notFound`, emitting the `notFound` code instead of its own.
     static notFound(options?: ComponentErrorOptions): BuilderError {
-        return super.notFound(options);
+        return new BuilderError({
+            code: ErrorCode.NOT_FOUND,
+            ...options,
+        });
     }
 
     static registryNotFound(options?: ComponentErrorOptions): BuilderError {
-        return super.notFound(options);
+        return new BuilderError({
+            code: ErrorCode.REGISTRY_NOT_FOUND,
+            ...options,
+        });
+    }
+
+    static registryProjectNotFound(message?: string) {
+        return new BuilderError({
+            code: ErrorCode.REGISTRY_PROJECT_NOT_FOUND,
+            message,
+        });
     }
 
     static entrypointNotFound(message?: string) {

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
@@ -28,6 +28,7 @@ import {
     isDockerDistributionImageMissingError,
 } from '../../../../../adapters/docker/index.ts';
 import { isAnalysisProcessStale } from '../../../helpers.ts';
+import { BuilderError } from '../../../analysis-builder/error';
 
 export class AnalysisDistributorCheckHandler implements ComponentHandler<AnalysisDistributorEventMap, AnalysisDistributorCommand.CHECK> {
     protected coreClient: CoreClient;
@@ -115,6 +116,14 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
         }
 
         // -----------------------------------------------------------------------------------
+
+        // `analysis.registry_id` is nullable — it is unset until the distributor
+        // assigns one, and the registry FK detaches (SET NULL) if the registry is
+        // deleted while the analysis is in flight. Fail with a domain error rather
+        // than requesting `/registries/null`.
+        if (!analysis.registry_id) {
+            throw BuilderError.registryNotFound();
+        }
 
         const registry = await this.coreClient.registry.getOne(analysis.registry_id, { fields: ['+account_secret'] });
 

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Node, RegistryProject } from '@privateaim/core-kit';
 import {
     REGISTRY_ARTIFACT_TAG_LATEST,
 } from '@privateaim/core-kit';
@@ -129,13 +130,18 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
         // when the project is deleted, so the relation may be absent even though
         // the node is otherwise runnable. Validated up front rather than inside
         // the loop below, whose catch translates docker outcomes into a check
-        // verdict — a precondition failure must not be routed through that.
+        // verdict — a precondition failure must not be routed through that. The
+        // narrowed relation is collected alongside each node so the docker loop
+        // never re-dereferences the nullable relation.
+        const checks: { node: Node; registryProject: RegistryProject }[] = [];
         for (const node of nodes) {
             if (!node.registry_project) {
                 throw BuilderError.registryProjectNotFound(
                     `The node ${node.name} has no registry project.`,
                 );
             }
+
+            checks.push({ node, registryProject: node.registry_project });
         }
 
         const registry = await this.coreClient.registry.getOne(analysis.registry_id, { fields: ['+account_secret'] });
@@ -145,7 +151,7 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
         let status: `${ProcessStatus}`;
 
         try {
-            for (const node of nodes) {
+            for (const { node, registryProject } of checks) {
                 this.logger?.info({
                     message: `Checking analysis image of node ${node.name}`,
                     command: AnalysisDistributorCommand.CHECK,
@@ -155,7 +161,7 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
 
                 const nodeImageURL = buildDockerImageURL({
                     hostname: registry.host,
-                    projectName: node.registry_project.external_name,
+                    projectName: registryProject.external_name,
                     repositoryName: analysis.id,
                     tagOrDigest: REGISTRY_ARTIFACT_TAG_LATEST,
                 });

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/check/module.ts
@@ -125,6 +125,19 @@ export class AnalysisDistributorCheckHandler implements ComponentHandler<Analysi
             throw BuilderError.registryNotFound();
         }
 
+        // A node's registry project is optional and can be detached (SET NULL)
+        // when the project is deleted, so the relation may be absent even though
+        // the node is otherwise runnable. Validated up front rather than inside
+        // the loop below, whose catch translates docker outcomes into a check
+        // verdict — a precondition failure must not be routed through that.
+        for (const node of nodes) {
+            if (!node.registry_project) {
+                throw BuilderError.registryProjectNotFound(
+                    `The node ${node.name} has no registry project.`,
+                );
+            }
+        }
+
         const registry = await this.coreClient.registry.getOne(analysis.registry_id, { fields: ['+account_secret'] });
 
         const authConfig = buildDockerAuthConfigFromRegistry(registry);

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/execute/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/execute/module.ts
@@ -82,6 +82,15 @@ export class AnalysisDistributorExecuteHandler implements ComponentHandler<Analy
         );
 
         const analysis = await this.coreClient.analysis.getOne(value.id);
+
+        // `analysis.registry_id` is nullable — it is unset until the distributor
+        // assigns one, and the registry FK detaches (SET NULL) if the registry is
+        // deleted while the analysis is in flight. Fail with a domain error rather
+        // than requesting `/registries/null`.
+        if (!analysis.registry_id) {
+            throw BuilderError.registryNotFound();
+        }
+
         const registry = await this.coreClient.registry.getOne(analysis.registry_id, { fields: ['+account_secret'] });
 
         const analysisNodes = await getManyAll((page) => this.coreClient.analysisNode.getMany({

--- a/apps/server-core-worker/src/app/components/analysis-distributor/handlers/execute/module.ts
+++ b/apps/server-core-worker/src/app/components/analysis-distributor/handlers/execute/module.ts
@@ -187,6 +187,15 @@ export class AnalysisDistributorExecuteHandler implements ComponentHandler<Analy
 
         const tags : string[] = [];
         for (const node of nodes) {
+            // A node's registry project is optional and can be detached
+            // (SET NULL) when the project is deleted, so the relation may be
+            // absent even though the node is otherwise runnable.
+            if (!node.registry_project) {
+                throw BuilderError.registryProjectNotFound(
+                    `The node ${node.name} has no registry project.`,
+                );
+            }
+
             const nodeImageURL = buildDockerImageURL({
                 hostname: registry.host,
                 projectName: node.registry_project.external_name,

--- a/apps/server-core/src/adapters/database/entities/analysis.ts
+++ b/apps/server-core/src/adapters/database/entities/analysis.ts
@@ -30,7 +30,7 @@ import { MasterImageEntity } from './master-image.ts';
 import { ProjectEntity } from './project.ts';
 import { RegistryEntity } from './registry.ts';
 
-@Entity({ name: 'analysis' })
+@Entity({ name: 'analyses' })
 export class AnalysisEntity implements Analysis {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -200,10 +200,15 @@ export class AnalysisEntity implements Analysis {
 
     // ------------------------------------------------------------------
 
+    // Detach on delete rather than cascade. A null `registry_id` is the normal
+    // pre-distribution state — `AnalysisDistributor.assignRegistry()` fills it
+    // in lazily — so losing the registry returns the analysis to a state the
+    // domain already handles. Cascading instead destroyed the analysis together
+    // with its buckets, bucket files, nodes and node events.
     @Column({ nullable: true })
     registry_id: Registry['id'] | null;
 
-    @ManyToOne(() => RegistryEntity, { onDelete: 'CASCADE', nullable: true })
+    @ManyToOne(() => RegistryEntity, { onDelete: 'SET NULL', nullable: true })
     @JoinColumn({ name: 'registry_id' })
     registry: RegistryEntity | null;
 

--- a/apps/server-core/src/adapters/database/entities/node.ts
+++ b/apps/server-core/src/adapters/database/entities/node.ts
@@ -63,19 +63,24 @@ export class NodeEntity implements Node {
 
     // ------------------------------------------------------------------
 
+    // Both registry references detach on delete rather than cascade. A node is
+    // an independent, long-lived resource (it owns its realm, crypto keys and
+    // client credentials) that merely *points at* registry-side rows — deleting
+    // a registry or a registry project must never take the node down with it.
+    // The node is simply left unassigned and can be reconnected.
     @Column({ nullable: true })
     registry_id: Registry['id'] | null;
 
-    @ManyToOne(() => RegistryEntity, { onDelete: 'CASCADE', nullable: true })
+    @ManyToOne(() => RegistryEntity, { onDelete: 'SET NULL', nullable: true })
     @JoinColumn({ name: 'registry_id' })
     registry: Registry | null;
 
     @Column({ nullable: true })
-    registry_project_id: RegistryProject['id'];
+    registry_project_id: RegistryProject['id'] | null;
 
-    @ManyToOne(() => RegistryProjectEntity, { onDelete: 'CASCADE', nullable: true })
+    @ManyToOne(() => RegistryProjectEntity, { onDelete: 'SET NULL', nullable: true })
     @JoinColumn({ name: 'registry_project_id' })
-    registry_project: RegistryProject;
+    registry_project: RegistryProject | null;
 
     @Column({ type: 'uuid', nullable: true })
     client_id: Client['id'] | null;

--- a/apps/server-core/src/adapters/database/migrations/mysql/1784000000000-RegistryFkSetNullAndRenameAnalysis.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1784000000000-RegistryFkSetNullAndRenameAnalysis.ts
@@ -1,0 +1,84 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Two schema changes:
+ *
+ * **1. Rename `analysis` to `analyses`.** Every other table is plural (`nodes`,
+ * `projects`, `registries`, `analysis_nodes`, `analysis_buckets`, …); the analysis
+ * table was the sole singular outlier. It was already renamed once —
+ * `analysis_entity` → `analysis` by `AddDisplayName1780300000000` — so this
+ * completes that move. Foreign keys pointing at the table (from
+ * `analysis_buckets`, `analysis_bucket_files`, `analysis_nodes`,
+ * `analysis_node_events`) are carried over by the rename, constraint names intact.
+ *
+ * **2. Detach from deleted registry-side rows instead of cascading.**
+ * `nodes.registry_id`, `nodes.registry_project_id` and `analyses.registry_id` were
+ * all created with `ON DELETE CASCADE`, which made two ordinary admin actions
+ * destructive far beyond their apparent scope:
+ *
+ * - removing a registry project deleted the node referencing it, losing that
+ *   node's realm, crypto keys and client credentials;
+ * - removing a registry deleted every node bound to it *and* every analysis using
+ *   it — and, through the analysis' own cascades, that analysis' buckets, bucket
+ *   files, nodes and node events.
+ *
+ * All three columns are nullable, and null is a state the domain already handles
+ * (an unassigned node; an analysis awaiting `AnalysisDistributor.assignRegistry()`),
+ * so the reference is nulled and the owning row survives.
+ *
+ * `registry_projects.registry_id` deliberately keeps its cascade — a registry
+ * project cannot exist without its registry.
+ */
+export class RegistryFkSetNullAndRenameAnalysis1784000000000 implements MigrationInterface {
+    name = 'RegistryFkSetNullAndRenameAnalysis1784000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('RENAME TABLE `analysis` TO `analyses`');
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\` DROP FOREIGN KEY \`FK_053b94f56b541609149d98c47c7\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\` DROP FOREIGN KEY \`FK_bcd8dfa9976ce5606c7ce4cf54e\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`analyses\` DROP FOREIGN KEY \`FK_deee2261a37e46654165218a889\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\`
+            ADD CONSTRAINT \`FK_053b94f56b541609149d98c47c7\` FOREIGN KEY (\`registry_id\`) REFERENCES \`registries\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\`
+            ADD CONSTRAINT \`FK_bcd8dfa9976ce5606c7ce4cf54e\` FOREIGN KEY (\`registry_project_id\`) REFERENCES \`registry_projects\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`analyses\`
+            ADD CONSTRAINT \`FK_deee2261a37e46654165218a889\` FOREIGN KEY (\`registry_id\`) REFERENCES \`registries\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`analyses\` DROP FOREIGN KEY \`FK_deee2261a37e46654165218a889\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\` DROP FOREIGN KEY \`FK_bcd8dfa9976ce5606c7ce4cf54e\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\` DROP FOREIGN KEY \`FK_053b94f56b541609149d98c47c7\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\`
+            ADD CONSTRAINT \`FK_053b94f56b541609149d98c47c7\` FOREIGN KEY (\`registry_id\`) REFERENCES \`registries\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`nodes\`
+            ADD CONSTRAINT \`FK_bcd8dfa9976ce5606c7ce4cf54e\` FOREIGN KEY (\`registry_project_id\`) REFERENCES \`registry_projects\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`analyses\`
+            ADD CONSTRAINT \`FK_deee2261a37e46654165218a889\` FOREIGN KEY (\`registry_id\`) REFERENCES \`registries\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query('RENAME TABLE `analyses` TO `analysis`');
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1784000000000-RegistryFkSetNullAndRenameAnalysis.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1784000000000-RegistryFkSetNullAndRenameAnalysis.ts
@@ -1,0 +1,88 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Two schema changes:
+ *
+ * **1. Rename `analysis` to `analyses`.** Every other table is plural (`nodes`,
+ * `projects`, `registries`, `analysis_nodes`, `analysis_buckets`, …); the analysis
+ * table was the sole singular outlier. It was already renamed once —
+ * `analysis_entity` → `analysis` by `AddDisplayName1780300000000` — so this
+ * completes that move. Foreign keys pointing at the table (from
+ * `analysis_buckets`, `analysis_bucket_files`, `analysis_nodes`,
+ * `analysis_node_events`) are carried over by the rename, constraint names intact.
+ *
+ * **2. Detach from deleted registry-side rows instead of cascading.**
+ * `nodes.registry_id`, `nodes.registry_project_id` and `analyses.registry_id` were
+ * all created with `ON DELETE CASCADE`, which made two ordinary admin actions
+ * destructive far beyond their apparent scope:
+ *
+ * - removing a registry project deleted the node referencing it, losing that
+ *   node's realm, crypto keys and client credentials;
+ * - removing a registry deleted every node bound to it *and* every analysis using
+ *   it — and, through the analysis' own cascades, that analysis' buckets, bucket
+ *   files, nodes and node events.
+ *
+ * All three columns are nullable, and null is a state the domain already handles
+ * (an unassigned node; an analysis awaiting `AnalysisDistributor.assignRegistry()`),
+ * so the reference is nulled and the owning row survives.
+ *
+ * `registry_projects.registry_id` deliberately keeps its cascade — a registry
+ * project cannot exist without its registry.
+ */
+export class RegistryFkSetNullAndRenameAnalysis1784000000000 implements MigrationInterface {
+    name = 'RegistryFkSetNullAndRenameAnalysis1784000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "analysis" RENAME TO "analyses"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes" DROP CONSTRAINT "FK_053b94f56b541609149d98c47c7"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes" DROP CONSTRAINT "FK_bcd8dfa9976ce5606c7ce4cf54e"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "analyses" DROP CONSTRAINT "FK_deee2261a37e46654165218a889"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes"
+            ADD CONSTRAINT "FK_053b94f56b541609149d98c47c7" FOREIGN KEY ("registry_id") REFERENCES "registries"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes"
+            ADD CONSTRAINT "FK_bcd8dfa9976ce5606c7ce4cf54e" FOREIGN KEY ("registry_project_id") REFERENCES "registry_projects"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "analyses"
+            ADD CONSTRAINT "FK_deee2261a37e46654165218a889" FOREIGN KEY ("registry_id") REFERENCES "registries"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "analyses" DROP CONSTRAINT "FK_deee2261a37e46654165218a889"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes" DROP CONSTRAINT "FK_bcd8dfa9976ce5606c7ce4cf54e"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes" DROP CONSTRAINT "FK_053b94f56b541609149d98c47c7"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes"
+            ADD CONSTRAINT "FK_053b94f56b541609149d98c47c7" FOREIGN KEY ("registry_id") REFERENCES "registries"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "nodes"
+            ADD CONSTRAINT "FK_bcd8dfa9976ce5606c7ce4cf54e" FOREIGN KEY ("registry_project_id") REFERENCES "registry_projects"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "analyses"
+            ADD CONSTRAINT "FK_deee2261a37e46654165218a889" FOREIGN KEY ("registry_id") REFERENCES "registries"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "analyses" RENAME TO "analysis"
+        `);
+    }
+}

--- a/apps/server-core/src/core/entities/node/service.ts
+++ b/apps/server-core/src/core/entities/node/service.ts
@@ -114,9 +114,23 @@ export class NodeService extends AbstractEntityService implements INodeService {
 
         const merged = this.repository.merge(entity, validated);
 
-        await this.syncRegistryProject(merged);
+        // Only an explicit `registry_id: null` disconnects the node. An update
+        // that merely omits the field (a rename, a visibility toggle, …) must
+        // never tear down the node's registry project as a side effect.
+        const registryCleared = typeof validated.registry_id !== 'undefined' &&
+            !validated.registry_id;
 
-        return this.repository.save(merged, { data: actor.metadata });
+        // Detach + persist before tearing the old project down: the node must
+        // never be left referencing a row that is about to disappear.
+        const orphaned = await this.syncRegistryProject(merged, registryCleared);
+
+        const saved = await this.repository.save(merged, { data: actor.metadata });
+
+        if (orphaned) {
+            await this.registryManager?.removeProject(orphaned);
+        }
+
+        return saved;
     }
 
     async delete(id: string, actor: ActorContext): Promise<Node> {
@@ -156,6 +170,12 @@ export class NodeService extends AbstractEntityService implements INodeService {
 
         if (!registryId) return;
 
+        // Record the assignment, including when it came from the default
+        // registry. Leaving `registry_id` null while a project exists is an
+        // inconsistent state: the node reads as "not connected" everywhere the
+        // column is the source of truth, yet owns a provisioned project.
+        entity.registry_id = registryId;
+
         const externalName = entity.external_name || createNanoID();
         entity.external_name = externalName;
 
@@ -173,24 +193,58 @@ export class NodeService extends AbstractEntityService implements INodeService {
         await this.registryManager.linkProject(registryProject.id);
     }
 
-    private async syncRegistryProject(entity: Node): Promise<void> {
-        if (!this.registryManager || !entity.registry_id) return;
+    /**
+     * Reconcile the node's registry project with its (possibly just changed)
+     * `registry_id`.
+     *
+     * Returns the registry project the node no longer references, if any. The
+     * caller must persist the node BEFORE removing it — see the note in
+     * {@see update}.
+     *
+     * @param cleared whether this update explicitly disconnected the node.
+     */
+    private async syncRegistryProject(
+        entity: Node,
+        cleared: boolean,
+    ): Promise<RegistryProject | undefined> {
+        if (!this.registryManager) return undefined;
 
-        const externalName = entity.external_name || createNanoID();
+        if (!entity.registry_id) {
+            if (!cleared) return undefined;
+
+            // Disconnected — detach the node from its project and hand the
+            // project back for teardown. Without this the node keeps a dangling
+            // `registry_project_id` and still resolves credentials from a
+            // registry it is no longer assigned to.
+            const current = entity.registry_project_id ?
+                await this.registryManager.findProject(entity.registry_project_id) :
+                null;
+
+            entity.registry_project_id = null;
+
+            if (!current) return undefined;
+
+            await this.registryManager.unlinkProject(current);
+
+            return current;
+        }
 
         let registryProject: RegistryProject | undefined;
         if (entity.registry_project_id) {
             registryProject = await this.registryManager.findProject(entity.registry_project_id) ?? undefined;
         }
 
+        const externalName = entity.external_name || createNanoID();
+
         // A registry project lives inside a single registry, so when the node is
         // re-assigned to a different registry the existing project can no longer
         // serve it. Tear it down and provision a fresh one on the new registry —
         // otherwise the node keeps resolving its credentials (and host) from the
         // old registry.
+        let orphaned: RegistryProject | undefined;
         if (registryProject && registryProject.registry_id !== entity.registry_id) {
             await this.registryManager.unlinkProject(registryProject);
-            await this.registryManager.removeProject(registryProject);
+            orphaned = registryProject;
             registryProject = undefined;
         }
 
@@ -217,6 +271,8 @@ export class NodeService extends AbstractEntityService implements INodeService {
 
         entity.registry_project_id = registryProject.id;
         entity.external_name = externalName;
+
+        return orphaned;
     }
 
     private async unlinkRegistryProject(entity: Node): Promise<void> {

--- a/apps/server-core/test/app/database.ts
+++ b/apps/server-core/test/app/database.ts
@@ -40,7 +40,26 @@ export function createTestDatabaseModule(): IModule {
 
         async setup(container: IContainer): Promise<void> {
             const optionsBuilder = new DataSourceOptionsBuilder();
-            const options = optionsBuilder.buildWithEnv();
+            let options = optionsBuilder.buildWithEnv();
+
+            // One database PER vitest worker. Spec files run in parallel across
+            // workers but sequentially within one, so this is what isolates the
+            // suites from each other: with a single shared database, any suite
+            // mutating global state races every other — e.g. a spec creating a
+            // registry makes `NodeService.create`'s default-registry fallback
+            // auto-connect the bare nodes of concurrently running suites, and
+            // deleting it again mid-flight fails their inserts on the
+            // nodes -> registries FK. sqlite needs no suffix (`:memory:` is
+            // already per data source).
+            if (options.type === 'mysql' || options.type === 'postgres') {
+                const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID;
+                if (workerId) {
+                    options = {
+                        ...options,
+                        database: `${options.database}_${workerId}`,
+                    };
+                }
+            }
 
             await createDatabase({
                 options,

--- a/apps/server-core/test/unit/core/entities/node/fake-registry-manager.ts
+++ b/apps/server-core/test/unit/core/entities/node/fake-registry-manager.ts
@@ -20,6 +20,10 @@ export class FakeRegistryManager implements IRegistryManager {
 
     private relinkCalls: RegistryProject[] = [];
 
+    private removeCalls: RegistryProject[] = [];
+
+    private removeObserver?: (project: RegistryProject) => void;
+
     setDefaultRegistryId(id: string | null): void {
         this.defaultRegistryId = id;
     }
@@ -52,6 +56,8 @@ export class FakeRegistryManager implements IRegistryManager {
     }
 
     async removeProject(project: RegistryProject): Promise<void> {
+        this.removeCalls.push(project);
+        this.removeObserver?.(project);
         this.projects = this.projects.filter((p) => p.id !== project.id);
     }
 
@@ -79,6 +85,20 @@ export class FakeRegistryManager implements IRegistryManager {
 
     getRelinkCalls(): RegistryProject[] {
         return [...this.relinkCalls];
+    }
+
+    getRemoveCalls(): RegistryProject[] {
+        return [...this.removeCalls];
+    }
+
+    /**
+     * Observe the exact moment a project is torn down. `nodes.registry_project_id`
+     * carries an `ON DELETE CASCADE` FK in the real schema, so removing a project
+     * a node still references deletes that node too — tests use this to assert the
+     * node was already detached and persisted before the removal happens.
+     */
+    observeRemoveProject(fn: (project: RegistryProject) => void): void {
+        this.removeObserver = fn;
     }
 
     getProjects(): RegistryProject[] {

--- a/apps/server-core/test/unit/core/entities/node/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/node/service.spec.ts
@@ -156,6 +156,20 @@ describe('NodeService', () => {
             expect(registryManager.getProjects()).toHaveLength(1);
         });
 
+        it('should record the registry assignment when it falls back to the default registry', async () => {
+            registryManager.setDefaultRegistryId('registry-1');
+
+            const result = await service.create(
+                { name: 'new-node' },
+                createMasterRealmActor(),
+            );
+
+            // A node owning a project but with a null `registry_id` reads as
+            // "not connected" everywhere the column is the source of truth.
+            expect(result.registry_id).toBe('registry-1');
+            expect(result.registry_project_id).toBe(registryManager.getProjects()[0].id);
+        });
+
         it('should convert non-hex public_key to hex', async () => {
             const result = await service.create(
                 { name: 'new-node', public_key: 'hello' },
@@ -270,6 +284,132 @@ describe('NodeService', () => {
             expect(registryManager.getUnlinkCalls()).toHaveLength(0);
             expect(registryManager.getProjects()).toHaveLength(1);
             expect(result.registry_project_id).toBe(registryProject.id);
+        });
+
+        it('should tear down the registry project when the registry is cleared', async () => {
+            const registryId = randomUUID();
+
+            const registryProject = createTestRegistryProject({
+                registry_id: registryId,
+                external_name: 'extname',
+            });
+            registryManager.seedProject(registryProject);
+
+            const node = createTestNode({
+                realm_id: 'realm-1',
+                registry_id: registryId,
+                registry_project_id: registryProject.id,
+                external_name: 'extname',
+            });
+            repository.seed(node);
+
+            const result = await service.update(
+                node.id,
+                { registry_id: null },
+                createMasterRealmActor(),
+            );
+
+            expect(registryManager.getUnlinkCalls()).toHaveLength(1);
+            expect(registryManager.getUnlinkCalls()[0].id).toBe(registryProject.id);
+            expect(registryManager.getProjects()).toHaveLength(0);
+
+            // No dangling reference: the node must not keep resolving credentials
+            // from a registry it is no longer assigned to.
+            expect(result.registry_id).toBeNull();
+            expect(result.registry_project_id).toBeNull();
+        });
+
+        it('should keep the registry project when an unrelated field is updated on a node with no registry_id', async () => {
+            // Nodes provisioned against the *default* registry before that
+            // assignment was recorded still carry `registry_id = null` while
+            // owning a project. A rename must not be read as a disconnect.
+            const registryProject = createTestRegistryProject({ external_name: 'extname' });
+            registryManager.seedProject(registryProject);
+
+            const node = createTestNode({
+                realm_id: 'realm-1',
+                registry_id: null,
+                registry_project_id: registryProject.id,
+                external_name: 'extname',
+            });
+            repository.seed(node);
+
+            const result = await service.update(
+                node.id,
+                { name: 'renamed-node' },
+                createMasterRealmActor(),
+            );
+
+            expect(registryManager.getUnlinkCalls()).toHaveLength(0);
+            expect(registryManager.getRemoveCalls()).toHaveLength(0);
+            expect(registryManager.getProjects()).toHaveLength(1);
+            expect(result.registry_project_id).toBe(registryProject.id);
+        });
+
+        it('should detach and persist the node before removing its registry project', async () => {
+            const registryId = randomUUID();
+
+            const registryProject = createTestRegistryProject({
+                registry_id: registryId,
+                external_name: 'extname',
+            });
+            registryManager.seedProject(registryProject);
+
+            const node = createTestNode({
+                realm_id: 'realm-1',
+                registry_id: registryId,
+                registry_project_id: registryProject.id,
+                external_name: 'extname',
+            });
+            repository.seed(node);
+
+            // `nodes.registry_project_id` is an `ON DELETE CASCADE` FK, so removing
+            // the project while the stored node still points at it would delete the
+            // node row. Capture what the repository holds at removal time.
+            let persistedAtRemoval: Node | null = null;
+            registryManager.observeRemoveProject(() => {
+                persistedAtRemoval = repository.getAll()
+                    .find((item) => item.id === node.id) ?? null;
+            });
+
+            await service.update(node.id, { registry_id: null }, createMasterRealmActor());
+
+            expect(registryManager.getRemoveCalls()).toHaveLength(1);
+            expect(persistedAtRemoval).not.toBeNull();
+            expect(persistedAtRemoval!.registry_project_id).toBeNull();
+        });
+
+        it('should detach and persist the node before removing the stale project on re-assignment', async () => {
+            const registryId = randomUUID();
+            const nextRegistryId = randomUUID();
+
+            const registryProject = createTestRegistryProject({
+                registry_id: registryId,
+                external_name: 'extname',
+            });
+            registryManager.seedProject(registryProject);
+
+            const node = createTestNode({
+                realm_id: 'realm-1',
+                registry_id: registryId,
+                registry_project_id: registryProject.id,
+                external_name: 'extname',
+            });
+            repository.seed(node);
+
+            let referencedAtRemoval: string | null | undefined;
+            registryManager.observeRemoveProject(() => {
+                referencedAtRemoval = repository.getAll()
+                    .find((item) => item.id === node.id)?.registry_project_id;
+            });
+
+            await service.update(node.id, { registry_id: nextRegistryId }, createMasterRealmActor());
+
+            // The node already points at the freshly provisioned project — never at
+            // the one being removed.
+            expect(registryManager.getRemoveCalls()).toHaveLength(1);
+            expect(registryManager.getRemoveCalls()[0].id).toBe(registryProject.id);
+            expect(referencedAtRemoval).not.toBe(registryProject.id);
         });
     });
 

--- a/apps/server-core/test/unit/http/node.spec.ts
+++ b/apps/server-core/test/unit/http/node.spec.ts
@@ -5,11 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { faker } from '@faker-js/faker';
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import type {
@@ -72,5 +73,55 @@ describe('src/controllers/core/node', () => {
         const { client } = suite;
 
         await client.node.delete(details.id);
+    });
+
+    it('should survive registry deletion with detached references', async () => {
+        const { client } = suite;
+
+        const registry = await client.registry.create({
+            name: faker.string.alpha({ length: 16, casing: 'lower' }),
+            host: faker.internet.domainName(),
+        });
+
+        const node = await client.node.create(createTestNode({ registry_id: registry.id }));
+        expect(node.registry_id).toEqual(registry.id);
+        // connecting provisions a registry project
+        expect(node.registry_project_id).toBeDefined();
+
+        await client.registry.delete(registry.id);
+
+        // The registry FKs detach (SET NULL) instead of cascading: the node must
+        // survive the registry deletion with its references nulled.
+        const found = await client.node.getOne(node.id);
+        expect(found.id).toEqual(node.id);
+        expect(found.registry_id).toBeNull();
+        expect(found.registry_project_id).toBeNull();
+    });
+
+    it('should tear down the registry project on disconnect', async () => {
+        const { client } = suite;
+
+        const registry = await client.registry.create({
+            name: faker.string.alpha({ length: 16, casing: 'lower' }),
+            host: faker.internet.domainName(),
+        });
+
+        const node = await client.node.create(createTestNode({ registry_id: registry.id }));
+        expect(node.registry_project_id).toBeDefined();
+
+        // An explicit `registry_id: null` disconnects — the null must survive the
+        // whole HTTP path (JSON body, validator) and detach the node.
+        const updated = await client.node.update(node.id, { registry_id: null });
+        expect(updated.registry_id).toBeNull();
+        expect(updated.registry_project_id).toBeNull();
+
+        // ... and the provisioned registry project is removed, not orphaned.
+        const { data: projects } = await client.registryProject.getMany({ filters: { registry_id: registry.id } });
+        expect(projects).toHaveLength(0);
+
+        // Clean up: a registry left behind would make the default-registry
+        // fallback auto-connect the bare nodes of suites that run later in
+        // this worker's database.
+        await client.registry.delete(registry.id);
     });
 });

--- a/docs/src/guide/deployment/configuration.md
+++ b/docs/src/guide/deployment/configuration.md
@@ -28,6 +28,21 @@ Used by `server-core`, `server-storage`, and `server-telemetry`:
 
 *Not required for SQLite.
 
+### SQLite has no upgrade path
+
+Migrations only run for `mysql` and `postgres`. On SQLite the schema is built from
+the entity classes by `synchronize()`, and only when no schema exists yet — so an
+**existing** SQLite database is never migrated or altered on upgrade.
+
+Schema changes therefore break a persistent SQLite deployment. The rename of the
+`analysis` table to `analyses` is one such change: a SQLite database created before
+it keeps the old table, and queries against the new name fail.
+
+Use SQLite only for tests and throwaway/in-memory (`:memory:`) instances. For any
+database you intend to keep, use MySQL or PostgreSQL. To carry an existing SQLite
+database across a schema change, export its data and re-import it into a freshly
+created database.
+
 ## Storage Variables (server-storage)
 
 | Variable | Required | Description |

--- a/docs/src/guide/user/nodes.md
+++ b/docs/src/guide/user/nodes.md
@@ -17,6 +17,27 @@ Nodes are registered in the Hub with:
 3. **Assign to projects** — nodes are added to projects via `ProjectNode` associations
 4. **Execute analyses** — the worker distributes analysis containers to assigned nodes
 
+## Registry Connection
+
+A node pushes and pulls analysis images through its own **registry project** — a
+dedicated project in the docker registry with its own robot account. This is
+managed on the node's **Registry** tab (`/admin/nodes/:id/registry`):
+
+- **Connect** — pick a registry and connect. Hub provisions a registry project
+  and robot account for the node and links them in the registry.
+- **Disconnect** — clears the node's registry assignment and removes its
+  registry project together with the robot account. The node itself is kept;
+  reconnecting provisions a **new** project, so the node has to pull fresh
+  credentials.
+
+The tab also shows the node's current registry credentials (host, project,
+account name and secret) and a secondary link/unlink action that repairs the
+registry-side state of an already-provisioned project without changing the
+node's assignment.
+
+Deleting a registry or a registry project never deletes the nodes referencing
+it — those nodes are simply left unassigned and can be reconnected.
+
 ## API Endpoints
 
 | Method | Endpoint | Description |

--- a/packages/client-vue/src/components/node/FNodeForm.ts
+++ b/packages/client-vue/src/components/node/FNodeForm.ts
@@ -12,14 +12,13 @@ import { useValidup } from '@validup/vue';
 import type { Severity } from '@validup/vue';
 import { createValidator } from '@validup/zod';
 import { z } from 'zod';
-import type { Node, Registry } from '@privateaim/core-kit';
+import type { Node } from '@privateaim/core-kit';
 import {
     DomainType,
     NodeType,
     NodeValidator,
 } from '@privateaim/core-kit';
 import { ValidatorGroup } from '@privateaim/kit';
-import { VCButton } from '@vuecs/button';
 import { extend } from '@vuecs/core';
 import {
     VCFormCheckbox,
@@ -37,11 +36,10 @@ import {
     h,
     reactive,
     ref,
-    resolveComponent,
     watch,
 } from 'vue';
 import { useUpdatedAt } from '../../composables';
-import type { ListBodySlotProps, ListItemSlotProps } from '../../core';
+import type { ListBodySlotProps } from '../../core';
 import {
     EntityListSlotName,
     buildFormSubmit,
@@ -50,7 +48,6 @@ import {
     initFormAttributesFromSource,
     wrapFnWithBusyState,
 } from '../../core';
-import RegistryList from '../registry/FRegistries';
 
 export default defineComponent({
     props: {
@@ -89,11 +86,15 @@ export default defineComponent({
         }
 
         const busy = ref(false);
+        // No `registry_id` here on purpose: the node ↔ registry assignment is
+        // owned by `FNodeRegistryConnection` on the node's Registry tab, where
+        // connect/disconnect is an explicit, immediate action (it provisions or
+        // tears down a registry project server-side) rather than a side effect
+        // of saving this general form.
         const form = reactive({
             name: '',
             external_name: '',
             realm_id: '',
-            registry_id: '',
             hidden: false,
             type: NodeType.DEFAULT,
         });
@@ -152,17 +153,7 @@ export default defineComponent({
             await manager.createOrUpdate(form as Partial<Node>);
         });
 
-        const toggleFormData = <T extends keyof typeof form>(key: T, id: any) => {
-            if (form[key] === id) {
-                form[key] = null as any;
-            } else {
-                form[key] = id;
-            }
-        };
-
-
         return () => {
-            const VCIcon = resolveComponent('VCIcon');
             let realm : VNodeArrayChildren = [];
             if (!isRealmLocked.value) {
                 realm = [
@@ -275,32 +266,6 @@ export default defineComponent({
                 },
             );
 
-            const registry : VNodeArrayChildren = [
-                h(
-                    VCFormGroup,
-                    {
-                        label: true,
-                        labelContent: 'Registry',
-                    },
-                    {
-                        default: () => h(RegistryList, {}, {
-                            [EntityListSlotName.ITEM_ACTIONS]: (props: ListItemSlotProps<Registry>) => h(VCButton, {
-                                disabled: props.busy,
-                                size: 'xs',
-                                color: form.registry_id === props.data.id ? 'warning' : 'neutral',
-                                onClick($event: any) {
-                                    $event.preventDefault();
-
-                                    toggleFormData('registry_id', props.data.id);
-                                },
-                            }, () => [
-                                h(VCIcon, { name: form.registry_id === props.data.id ? 'fa6-solid:minus' : 'fa6-solid:plus' }),
-                            ]),
-                        }),
-                    },
-                ),
-            ];
-
             const submitNode = buildFormSubmit({
                 submit,
                 busy: busy.value,
@@ -315,9 +280,6 @@ export default defineComponent({
                         name,
                         h('hr'),
                         externalName,
-                        h('hr'),
-                        registry,
-
                     ]),
                     h('div', { class: 'flex-1 basis-0 px-2' }, [
                         type,

--- a/packages/client-vue/src/components/node/FNodeRegistryConnection.vue
+++ b/packages/client-vue/src/components/node/FNodeRegistryConnection.vue
@@ -1,0 +1,191 @@
+<!--
+  - Copyright (c) 2026.
+  - Author Peter Placzek (tada5hi)
+  - For the full copyright and license information,
+  - view the LICENSE file that was distributed with this source code.
+  -->
+<script lang="ts">
+import type { Node } from '@privateaim/core-kit';
+import { DomainType } from '@privateaim/core-kit';
+import { VCButton } from '@vuecs/button';
+import { VCAlert } from '@vuecs/elements';
+import { VCIcon } from '@vuecs/icon';
+import {
+    computed,
+    defineComponent,
+    ref,
+    toRef,
+    watch,
+} from 'vue';
+import type { PropType } from 'vue';
+import { createEntityManager, defineEntityManagerEvents, wrapFnWithBusyState } from '../../core';
+import FRegistries from '../registry/FRegistries';
+
+export default defineComponent({
+    components: {
+        FRegistries,
+        VCAlert,
+        VCButton,
+        VCIcon,
+    },
+    props: {
+        entity: {
+            type: Object as PropType<Node>,
+            required: true,
+        },
+    },
+    emits: defineEntityManagerEvents<Node>(),
+    setup(props, setup) {
+        const entity = toRef(props, 'entity');
+        const busy = ref(false);
+
+        // The node's own entity manager — connecting/disconnecting is a plain
+        // `registry_id` update. The server reacts to it by provisioning a
+        // registry project (+ Harbor robot account) or tearing the existing one
+        // down, and answers with the updated node.
+        const manager = createEntityManager({
+            type: `${DomainType.NODE}`,
+            setup,
+            props: { entity: entity.value },
+        });
+
+        // `manager.data` wins over the prop: after an update it holds the fresh
+        // server response, while the parent's copy is only patched afterwards.
+        const current = computed(() => manager.data.value ?? entity.value);
+        const connected = computed(() => !!current.value.registry_id);
+        const hasProject = computed(() => !!current.value.registry_project_id);
+
+        // Staged selection: picking a registry in the list only marks it, the
+        // update is deferred to an explicit Connect click. Provisioning is not
+        // free (it creates a Harbor project + robot account), so it should never
+        // fire from a stray click in the list.
+        const selectedId = ref<string | null>(null);
+
+        watch(entity, (value) => {
+            manager.data.value = value;
+            selectedId.value = null;
+        });
+
+        const select = (id: string) => {
+            selectedId.value = selectedId.value === id ? null : id;
+        };
+
+        const connect = wrapFnWithBusyState(busy, async () => {
+            const id = selectedId.value;
+            if (!id) return;
+
+            await manager.update({ registry_id: id });
+
+            // `update()` reports failure through the `failed` event rather than
+            // throwing, so confirm it landed before dropping the selection —
+            // otherwise a failed connect silently loses the user's pick.
+            if (manager.data.value?.registry_id === id) {
+                selectedId.value = null;
+            }
+        });
+
+        const disconnect = wrapFnWithBusyState(busy, async () => {
+            await manager.update({ registry_id: null });
+        });
+
+        return {
+            busy,
+            connected,
+            hasProject,
+            selectedId,
+            select,
+            connect,
+            disconnect,
+        };
+    },
+});
+</script>
+<template>
+    <div>
+        <h6>Registry</h6>
+
+        <p>
+            Connecting the node to a registry provisions a dedicated registry project
+            with its own robot account, which the node uses to push and pull images.
+        </p>
+
+        <template v-if="connected">
+            <VCAlert
+                color="success"
+                variant="soft"
+                size="sm"
+                class="mb-3"
+            >
+                <VCIcon
+                    name="fa6-solid:plug"
+                    class="pe-1"
+                /> This node is connected to a registry.
+                <template v-if="!hasProject">
+                    Its registry project has not been provisioned yet.
+                </template>
+            </VCAlert>
+
+            <VCAlert
+                color="warning"
+                variant="soft"
+                size="sm"
+                class="mb-3"
+            >
+                Disconnecting removes the node's registry project and its robot account.
+                Reconnecting provisions a new one — the node will have to pull fresh
+                credentials.
+            </VCAlert>
+
+            <div>
+                <VCButton
+                    color="error"
+                    size="xs"
+                    :disabled="busy"
+                    @click.prevent="disconnect"
+                >
+                    <VCIcon
+                        name="fa6-solid:power-off"
+                        class="pe-1"
+                    /> Disconnect
+                </VCButton>
+            </div>
+        </template>
+        <template v-else>
+            <VCAlert
+                color="warning"
+                variant="soft"
+                size="sm"
+                class="mb-3"
+            >
+                This node is not connected to a registry. Select one below to connect it.
+            </VCAlert>
+
+            <FRegistries>
+                <template #itemActions="itemProps">
+                    <VCButton
+                        :disabled="itemProps.busy || busy"
+                        size="xs"
+                        :color="selectedId === itemProps.data.id ? 'warning' : 'neutral'"
+                        @click.prevent="select(itemProps.data.id)"
+                    >
+                        <VCIcon :name="selectedId === itemProps.data.id ? 'fa6-solid:minus' : 'fa6-solid:plus'" />
+                    </VCButton>
+                </template>
+            </FRegistries>
+
+            <div class="mt-3">
+                <VCButton
+                    color="primary"
+                    size="xs"
+                    :disabled="busy || !selectedId"
+                    @click.prevent="connect"
+                >
+                    <VCIcon
+                        name="fa6-solid:plug"
+                        class="pe-1"
+                    /> Connect
+                </VCButton>
+            </div>
+        </template>
+    </div>
+</template>

--- a/packages/client-vue/src/components/node/index.ts
+++ b/packages/client-vue/src/components/node/index.ts
@@ -11,3 +11,4 @@ export { default as FNodes } from './FNodes';
 export { default as FNodeRegistryProject } from './FNodeRegistryProject';
 export { default as FNodeClientCredentials } from './FNodeClientCredentials.vue';
 export { default as FNodeRegistryCredentials } from './FNodeRegistryCredentials.vue';
+export { default as FNodeRegistryConnection } from './FNodeRegistryConnection.vue';

--- a/packages/core-kit/src/domains/analysis/entity.ts
+++ b/packages/core-kit/src/domains/analysis/entity.ts
@@ -119,7 +119,7 @@ export interface Analysis {
 
     // ------------------------------------------------------------------
 
-    registry: Registry;
+    registry: Registry | null;
 
     registry_id: Registry['id'] | null;
 

--- a/packages/core-kit/src/domains/analysis/entity.ts
+++ b/packages/core-kit/src/domains/analysis/entity.ts
@@ -121,7 +121,7 @@ export interface Analysis {
 
     registry: Registry;
 
-    registry_id: Registry['id'];
+    registry_id: Registry['id'] | null;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/node/entity.ts
+++ b/packages/core-kit/src/domains/node/entity.ts
@@ -27,7 +27,7 @@ export interface Node {
 
     // ------------------------------------------------------------------
 
-    registry_id: Registry['id'];
+    registry_id: Registry['id'] | null;
 
     registry: Registry;
 

--- a/packages/core-kit/src/domains/node/entity.ts
+++ b/packages/core-kit/src/domains/node/entity.ts
@@ -29,11 +29,11 @@ export interface Node {
 
     registry_id: Registry['id'] | null;
 
-    registry: Registry;
+    registry: Registry | null;
 
     registry_project_id: RegistryProject['id'] | null;
 
-    registry_project: RegistryProject;
+    registry_project: RegistryProject | null;
 
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
Started from the bugged projects sidebar on `/admin/services/registry/:id/projects` and, following that thread, found a schema-level problem that made registry deletion far more destructive than it looks.

## 1. The sidebar bug

The registry detail tab strip is a horizontal `variant="pills"` nav with no `orientation`, so `@vuecs/navigation` resolves submenus to **collapse** mode. Giving the "Projects" tab a `children` array turned that segment into a non-navigable `<button>` trigger wrapping an expanded vertical `<ul>` **inside** the pill strip — a sidebar in the topbar. It was the only pills nav in the app with children.

The overview/add sub-navigation now lives in `[id]/projects.vue` as its own vertical sidebar, matching `projects/[id]/analyses.vue`. The flattened tab needs an explicit `activeMatch`: on `/projects/add` and `/projects/:id` it otherwise only scores a prefix match, ties with the back arrow and "General", and loses the tie to the first item.

Two neighbouring bugs on the same route are fixed too: the registry-project detail page resolved `route.params.id` (the *registry* id) as the project id so it never loaded, and four `navigateTo` targets pointed at `/admin/registries*`, which does not exist.

## 2. Registry deletion no longer destroys nodes and analyses

`nodes.registry_id`, `nodes.registry_project_id` and `analysis.registry_id` were all `ON DELETE CASCADE`:

- removing a **registry project** deleted the node referencing it — along with that node's realm, crypto keys and client credentials;
- removing a **registry** deleted every node bound to it *and* every analysis using it, and through the analysis' own cascades that analysis' buckets, bucket files, nodes and node events.

All three columns are nullable and null is a state the domain already handles (an unassigned node; an analysis awaiting `AnalysisDistributor.assignRegistry()`), so they become `ON DELETE SET NULL`. `registry_projects.registry_id` keeps its cascade — a registry project cannot exist without its registry.

Verified against real MySQL and PostgreSQL by seeding registry → project → node → analysis → analysis_node and deleting the registry:

| | nodes | analysis | analysis_nodes |
|---|---|---|---|
| before | **0** | **0** | **0** |
| after | 1, refs NULL | 1, `registry_id` NULL | 1 |

## 3. Connect/disconnect on the node Registry tab

That tab only rendered credentials; the registry assignment was buried in the general node form, where connecting or disconnecting happened as a side effect of saving unrelated fields.

`FNodeRegistryConnection` now owns the assignment as an explicit action — pick a registry and connect (the server provisions a registry project + robot account) or disconnect (it tears them down). The picker is gone from `FNodeForm`. `FRegistryProject`'s Harbor link/unlink stays below as a secondary repair action for an already-provisioned project.

Selecting a registry only *stages* it: provisioning is not free, so it must not fire from a stray click. A failed connect keeps the selection, because `EntityManager.update()` reports failure through an event rather than by throwing.

## 4. `analysis` → `analyses`

It was the only singular table name; every other one is plural. It ships in the same migration as the FK change, whose file name and doc comment name both changes — see the convention note below.

## Bugs surfaced along the way

- `NodeService.create()` never recorded `registry_id` when it fell back to the default registry, leaving nodes that own a registry project but read as "not connected" everywhere the column is the source of truth.
- With that state present, an update *omitting* `registry_id` was indistinguishable from an explicit disconnect — so a rename would have torn the node's registry project down. Only an explicit `registry_id: null` disconnects now.
- `NodeService.update()` removed the old registry project *before* persisting the node, so the node briefly referenced a row that was being deleted. It now detaches and persists first.
- The distributor's check/execute handlers passed `analysis.registry_id` straight into a URL; a live analysis can now legitimately have none, so they fail with a domain error instead of requesting `/registries/null`.

## Conventions

`.agents/conventions.md` had no migrations section. Added one, extracted from authup's: a migration per feature in both dialects with a doc-comment header, consolidation at release time, released migrations immutable, and a `run → revert × N → run` round-trip after every change.

Hub diverges on one point, and this PR is the reason: several changes **may** share a migration file, provided the file name and doc comment name every one of them. The failure mode worth preventing is not bundling but *concealment* — `AddDisplayName1780300000000` silently renamed `analysis_entity` → `analysis`, and that hidden rename misled the first draft of this PR's migration into targeting a table that no longer existed.

## Verification

- Full chain `run → revert → run` on real PostgreSQL **and** MySQL. `up()` renames then applies the set-null rules; `down()` restores the cascades then renames back. After the rename the SET NULL rules survive and all four child FKs re-point at `analyses`.
- 5 new `NodeService` tests, each confirmed to fail against the pre-fix code.
- Full suite green on this branch: 712 tests / 11 projects, 26 builds including `nuxi typecheck` and `vue-tsc`, lint clean.

## Not covered

- MySQL DDL is not transactional, so a migration that fails halfway leaves the schema partially altered — noted in the conventions; it needs a fresh database rather than a retry.
- `FNodeRegistryConnection` is not permission-gated in the UI (the server enforces `NODE_UPDATE`), consistent with `FNodeForm` before it. `client-vue` has no test target, so the component is covered only by `vue-tsc` and manual reasoning.
- Detaching a node keeps its `external_name`, so reconnecting reuses it. Two disconnected nodes sharing an `external_name` would only collide on reconnect to the same registry, since the `(external_name, registry_id)` unique index does not constrain NULLs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated “Registry Connection” experience for nodes (connect/disconnect, staged registry selection, connection status).
  - Improved admin navigation for registry projects with updated tabs and routing.

- **Bug Fixes**
  - Nodes/analyses now remain when registries are deleted: foreign keys are detached (set to null) instead of cascading deletes.
  - Registry project cleanup now occurs correctly on explicit disconnect/reassignment.
  - Added guardrails to prevent registry/project lookups with missing relationships.

- **Documentation**
  - Added database migration and table-naming conventions, plus SQLite “no upgrade path” guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->