### PR TITLE
perf(client-ui): ship only the icons the UI renders

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -311,6 +311,37 @@ These stay snake_case and must not be swept into a rename:
   VictoriaLogs query syntax.
 - Environment variables.
 
+## Icons
+
+`apps/client-ui` bundles only the icons it renders: `@nuxt/icon`'s standalone
+vite plugin (options in `apps/client-ui/icon-bundle.config.ts`) scans source for
+`<collection>:<name>` literals and emits that subset into
+`virtual:nuxt-icon-bundle/register`, which `plugins/vuecs.ts` imports. It
+registers through `addIcon` from `@iconify/vue` — the same global store
+`<VCIcon>` resolves against — so no component knows about it.
+
+**Rule: an icon name must be a literal.** A composed name is invisible to the
+scan, so it is never bundled and `@iconify/vue` falls back to fetching it from
+the public Iconify API at runtime:
+
+```vue
+<!-- Bad — never bundled; resolved over the network, or not at all -->
+<VCIcon :name="'fa6-brands:' + entity.buildOs" />
+
+<!-- Good — a computed switch over literals (FProcessStatus.vue,
+     FAnalysisBuildStep.vue) -->
+<VCIcon v-if="buildOsIcon" :name="buildOsIcon" />
+```
+
+The same applies to `packages/client-vue` and `packages/client-vue-theme`: they
+are scanned as source, and they are published, so a consuming app's scanner sees
+exactly the same literals.
+
+Both halves fail **silently** — an unmatched glob or a composed name yields an
+empty icon slot, not a build error. `apps/client-ui/test/unit/icon-bundle.spec.ts`
+guards the glob list by pinning one uniquely-attributable icon per scanned
+source; it drives the real plugin, so it needs no build output.
+
 ## Logging
 
 Logs flow through Winston → `LoggerTransport` (`packages/server-telemetry-kit/src/services/logger/transport.ts`) → telemetry/VictoriaLogs, where every string/number/boolean key of the metadata object becomes a **queryable label**. UI views (e.g. the analysis log panel) filter by these labels — see `AnalysisLogController`, which queries `refType=analysis` + `refId=<id>`.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -364,6 +364,26 @@ first. `nx.json`'s `test: { dependsOn: ["^build"] }` handles that for
 `npx nx run-many -t test`; a bare `npm run test -w packages/client-vue` on a
 cold tree does not.
 
+## Build-Config Tests (client-ui)
+
+`apps/client-ui/test/` is a plain node vitest config with no plugins — it
+renders nothing. Its one suite, `unit/icon-bundle.spec.ts`, guards the icon
+subset the app ships (see [conventions.md](conventions.md#icons)) by pinning one
+uniquely-attributable icon per scanned source, so removing any glob fails
+exactly one assertion.
+
+It drives the real `@nuxt/icon` plugin object — `load('\0virtual:nuxt-icon-bundle')`
+runs the whole scan → resolve → generate path by itself — rather than reading a
+built bundle. That is deliberate: CI's build cache carries only `**/dist/**` and
+`.nx`, so `apps/client-ui/.output` does **not** survive into the test job, and a
+spec asserting against it would either fail or need extra cache plumbing.
+Asserting a rendered page cannot work at all — `@iconify/vue` resolves icons
+client-side, so SSR output carries empty `<svg>` shells either way.
+
+Note `nuxi typecheck` (client-ui's `build:types`) **does** cover `test/**` under
+Nuxt 4 strict, unlike every other workspace, whose `tsconfig.build.json` includes
+`src/**` only.
+
 ## Fakes Over Mocks
 
 **Always prefer fake implementations over `vi.fn()` / `vi.mock()`.** The hexagonal architecture with dependency inversion makes every dependency injectable via a port interface — if it doesn't, that's a signal the architecture isn't fully hexagonal yet and should be fixed.

--- a/apps/client-ui/icon-bundle.config.ts
+++ b/apps/client-ui/icon-bundle.config.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import path from 'node:path';
+import type { NuxtIconVitePluginOptions } from '@nuxt/icon/vite';
+
+const repositoryRoot = path.resolve(import.meta.dirname, '..', '..');
+
+/**
+ * Options for `@nuxt/icon`'s standalone vite plugin, which bundles ONLY the
+ * icons this app renders instead of registering the whole Font Awesome 6
+ * solid + brands collections at runtime (1,902 icons, ~429 KB gzip, for the
+ * 115 actually used).
+ *
+ * The plugin scans source for `<collection>:<name>` literals and emits them
+ * into `virtual:nuxt-icon-bundle/register`, which registers through `addIcon`
+ * from `@iconify/vue` — the same global store `<VCIcon>` resolves against, so
+ * no component changes are needed.
+ *
+ * Kept out of `nuxt.config.ts` so `test/unit/icon-bundle.spec.ts` can drive
+ * the real plugin with the real options: the glob list is LOAD-BEARING and
+ * fails silently — a path that stops matching yields an empty icon slot in
+ * the browser, not a build error.
+ */
+export const iconBundleOptions: NuxtIconVitePluginOptions = {
+    // The repository root, so the globs below can reach the sibling workspace
+    // packages AND so `@iconify-json/*` resolves from the hoisted node_modules.
+    cwd: repositoryRoot,
+    scan: {
+        // Every source that can carry an icon name must be listed here.
+        // `.ts` is part of the extensions (the plugin default covers
+        // `.vue`/`.jsx`/`.tsx` only) because plenty of names live in plain
+        // TypeScript modules — nav item tables, status maps, presets.
+        globInclude: [
+            // This app's own template/config tree.
+            'apps/client-ui/*.vue',
+            'apps/client-ui/{components,composables,config,core,layouts,middleware,pages,plugins,utils}/**/*.{vue,ts}',
+            // Aliased to `src` in nuxt.config.ts, so its SOURCE — not its
+            // dist — is what gets compiled into this app.
+            'packages/client-vue/src/**/*.{vue,ts}',
+            // Carries no icon name today; listed so a theme that later ships
+            // icon defaults (the way vuecs presets do) works without a change
+            // here.
+            'packages/client-vue-theme/src/**/*.{vue,ts}',
+            // Its components and identity-provider preset tables hold ~50 names.
+            'node_modules/@authup/client-web-kit/dist/**/*.mjs',
+            // Supplies the vuecs behavioral defaults (pagination arrows,
+            // submit-button, alert icons, collapse chevrons). Those 11 names
+            // exist in no hub source file, so omitting this path silently
+            // empties those slots.
+            'node_modules/@vuecs/icons-font-awesome/dist/*.mjs',
+        ],
+        // Overrides the plugin default, which ignores `node_modules` and
+        // `dist` and would therefore drop the last two entries above.
+        globExclude: [],
+    },
+};

--- a/apps/client-ui/nuxt.config.ts
+++ b/apps/client-ui/nuxt.config.ts
@@ -9,11 +9,19 @@ import type { ModuleOptions } from '@authup/client-web-nuxt';
 import path from 'node:path';
 import { defineNuxtConfig } from 'nuxt/config';
 import tailwindcss from '@tailwindcss/vite';
+import { NuxtIconBundle } from '@nuxt/icon/vite';
+import { iconBundleOptions } from './icon-bundle.config.ts';
 
 export default defineNuxtConfig({
     vite: {
         plugins: [
             tailwindcss(),
+            // Ship only the icons this app renders — @nuxt/icon's STANDALONE
+            // vite plugin, not the Nuxt module. `plugins/vuecs.ts` imports the
+            // `virtual:nuxt-icon-bundle/register` module it emits. The options
+            // (and the reasoning behind every glob) live next door, so
+            // `test/unit/icon-bundle.spec.ts` can pin them.
+            NuxtIconBundle(iconBundleOptions),
         ],
     },
 

--- a/apps/client-ui/package.json
+++ b/apps/client-ui/package.json
@@ -18,7 +18,8 @@
         "start": "nuxi start",
         "generate": "nuxi generate",
         "prepare": "nuxi prepare",
-        "typecheck": "nuxi typecheck"
+        "typecheck": "nuxi typecheck",
+        "test": "vitest run --config test/vitest.config.ts"
     },
     "devDependencies": {
         "@authup/access": "^1.0.0-beta.58",
@@ -35,6 +36,7 @@
         "@ilingo/validup": "^1.1.0",
         "@ilingo/validup-vue": "^1.1.0",
         "@ilingo/vue": "^6.1.0",
+        "@nuxt/icon": "^2.4.1",
         "@nuxtjs/google-fonts": "^3.2.0",
         "@pinia/nuxt": "^1.0.1",
         "@privateaim/client-vue": "^0.13.0",
@@ -73,6 +75,7 @@
         "smob": "^1.6.2",
         "tailwindcss": "^4.3.3",
         "validup": "^1.0.0",
+        "vitest": "^4.1.10",
         "vue": "^3.5.40",
         "vue-tsc": "^3.3.8",
         "zod": "^4.4.3"

--- a/apps/client-ui/plugins/vuecs.ts
+++ b/apps/client-ui/plugins/vuecs.ts
@@ -14,9 +14,11 @@ import vuecs from '@vuecs/core';
 import clientWebKitTheme from '@authup/client-web-kit-theme';
 import clientVueTheme from '@privateaim/client-vue-theme';
 import fontAwesome from '@vuecs/icons-font-awesome';
-import { addCollection } from '@iconify/vue';
-import faBrands from '@iconify-json/fa6-brands/icons.json';
-import faSolid from '@iconify-json/fa6-solid/icons.json';
+// Registers the build-time icon subset (see `NuxtIconBundle` in
+// nuxt.config.ts) on `@iconify/vue`, which is the global store `<VCIcon>`
+// reads. Replaces `addCollection(faSolid)` + `addCollection(faBrands)`, which
+// pulled both full Font Awesome collections into the client bundle.
+import 'virtual:nuxt-icon-bundle/register';
 import installButton from '@vuecs/button';
 import installCountdown from '@vuecs/countdown';
 import installElements from '@vuecs/elements';
@@ -30,9 +32,6 @@ import installTable from '@vuecs/table';
 import installTimeago from '@vuecs/timeago';
 
 import { defineNuxtPlugin } from '#app';
-
-addCollection(faSolid);
-addCollection(faBrands);
 
 export default defineNuxtPlugin({
     name: 'vuecs',

--- a/apps/client-ui/test/unit/icon-bundle.spec.ts
+++ b/apps/client-ui/test/unit/icon-bundle.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { NuxtIconBundle } from '@nuxt/icon/vite';
+import {
+    beforeAll, 
+    describe, 
+    expect, 
+    it,
+} from 'vitest';
+import { iconBundleOptions } from '../../icon-bundle.config.ts';
+
+/**
+ * The app bundles only the icons it renders instead of registering both full
+ * Font Awesome collections. The plugin discovers icon names by SCANNING
+ * source, so its glob list is load-bearing and fails silently: a path that
+ * stops matching yields an empty icon slot in the browser, not a build error.
+ *
+ * Each glob that contributes icons is pinned below by a name that can come
+ * from it and from nowhere else. (`packages/client-vue-theme` carries no icon
+ * name today, so there is nothing to pin it with.)
+ *
+ * This drives the real plugin with the real options rather than asserting
+ * against a built bundle: `load()` performs the whole scan → resolve →
+ * generate path on its own, so the guard needs no `nuxi build` output — which
+ * CI's build cache does not carry anyway. Asserting against a rendered page
+ * would not work at all, since `@iconify/vue` resolves icons client-side and
+ * SSR output carries empty `<svg>` shells either way.
+ */
+// The `load` hook declares a rollup `PluginContext` receiver it never touches,
+// so it is callable standalone — but only through a signature that says so.
+type StandaloneLoad = (id: string) => unknown;
+
+type IconCollection = {
+    prefix?: string,
+    icons: Record<string, unknown>
+};
+
+describe('icon-bundle', () => {
+    let registered: Set<string>;
+
+    beforeAll(async () => {
+        const { load } = NuxtIconBundle(iconBundleOptions);
+        const hook = typeof load === 'function' ? load : load?.handler;
+
+        if (typeof hook !== 'function') {
+            throw new Error('@nuxt/icon no longer exposes a `load` hook');
+        }
+
+        // The plugin resolves its own virtual module id to a `\0`-prefixed one.
+        const code = await (hook as StandaloneLoad)('\0virtual:nuxt-icon-bundle');
+
+        if (typeof code !== 'string') {
+            throw new Error('the `load` hook did not emit the icon bundle');
+        }
+
+        // Emitted as `const collections = JSON.parse("<json>")`, so the inner
+        // literal parses twice: once as the JS string, once as the payload.
+        const [, payload] = /JSON\.parse\((".*")\)/s.exec(code) || [];
+
+        if (!payload) {
+            throw new Error('the emitted bundle no longer carries a JSON payload');
+        }
+
+        const collections = JSON.parse(JSON.parse(payload)) as IconCollection[];
+
+        registered = new Set(collections.flatMap((collection) => Object
+            .keys(collection.icons)
+            .map((name) => (collection.prefix ? `${collection.prefix}:${name}` : name))));
+    });
+
+    it('should bundle an icon only the vuecs preset references', () => {
+        // The pagination "first page" default, from @vuecs/icons-font-awesome.
+        expect(registered).toContain('fa6-solid:angles-left');
+    });
+
+    it('should bundle an icon only the authup kit references', () => {
+        // From the kit's identity-provider preset table.
+        expect(registered).toContain('fa6-brands:gitlab');
+    });
+
+    it('should bundle an icon only client-vue references', () => {
+        // FAnalysisBuildStep's build-OS icon.
+        expect(registered).toContain('fa6-brands:linux');
+    });
+
+    it('should bundle an icon only this app references', () => {
+        // The "analyses" navigation item.
+        expect(registered).toContain('fa6-solid:atom');
+    });
+
+    it('should not bundle the full font-awesome collections', () => {
+        // Two icons no hub source references. Their presence means the subset
+        // degraded back into a full-collection registration.
+        expect(registered).not.toContain('fa6-solid:chess-knight');
+        expect(registered).not.toContain('fa6-solid:bacterium');
+    });
+});

--- a/apps/client-ui/test/vitest.config.ts
+++ b/apps/client-ui/test/vitest.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { defineConfig } from 'vitest/config';
+
+// No plugins: the only suite here drives a vite plugin as a plain object and
+// renders nothing, so it needs neither a DOM nor SFC compilation.
+export default defineConfig({ test: { include: ['test/unit/**/*.spec.ts'] } });

--- a/apps/client-ui/types/icon-bundle.shim.d.ts
+++ b/apps/client-ui/types/icon-bundle.shim.d.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+// Declares the `virtual:nuxt-icon-bundle*` modules emitted by the
+// `NuxtIconBundle` vite plugin (see nuxt.config.ts). Without it,
+// `nuxi typecheck` fails on the side-effect import in plugins/vuecs.ts.
+/// <reference types="@nuxt/icon/client" />

--- a/docs/src/reference/frontend/client-vue.md
+++ b/docs/src/reference/frontend/client-vue.md
@@ -180,7 +180,10 @@ list handlers keep receiving `{ data, meta }`.
 
 - `vue` — Vue 3 framework (composition API)
 - `@vuecs/*` — component framework (forms, lists, tables, pagination, overlays, icons)
-- `@vuecs/icon` + Iconify — SVG icons (`fa6-solid` / `fa6-brands` collections; no webfont)
+- `@vuecs/icon` + Iconify — SVG icons (`fa6-solid` / `fa6-brands` collections; no webfont). Icon
+  names must be written as **literals** — consuming apps bundle only the names a build-time scan
+  finds in this package's source, so a composed name (`` `fa6-brands:${os}` ``) is never bundled.
+  See [client-ui — Icons](./index.md#icons).
 - `validup` / `@validup/vue` / `@validup/zod` — form validation wired to the core-kit Zod validators
 - `ilingo` / `@ilingo/vue` — translations
 - `@authup/client-web-kit` — authentication UI

--- a/docs/src/reference/frontend/index.md
+++ b/docs/src/reference/frontend/index.md
@@ -60,3 +60,26 @@ Authup built-in web client). The configured client **must** register
 - **@privateaim/client-vue** — shared component library
 - **@privateaim/core-http-kit** — typed HTTP client for Core API
 - **Authup client libraries** — authentication and authorization UI
+
+## Icons
+
+The client ships only the icons it actually renders. `@nuxt/icon`'s standalone vite plugin scans
+source for `<collection>:<name>` literals at build time and emits just that subset into
+`virtual:nuxt-icon-bundle/register`, which `plugins/vuecs.ts` imports. Registration goes through
+`addIcon` from `@iconify/vue` — the same global store `<VCIcon>` reads — so components are
+unaffected. This replaced registering the full Font Awesome 6 solid + brands collections (1,902
+icons, ~429 KB gzip) and cut the client JS payload from ~1,031 KB to ~623 KB gzip.
+
+The scanned paths are configured in `apps/client-ui/icon-bundle.config.ts`. They cover this app,
+`@privateaim/client-vue`, `@privateaim/client-vue-theme`, `@authup/client-web-kit` and
+`@vuecs/icons-font-awesome` (whose preset holds the vuecs behavioral defaults — pagination arrows,
+submit-button, alert and collapse icons — that appear in no hub source file).
+
+Two consequences for anyone adding an icon:
+
+- **Write the icon name as a literal.** A composed name (`` `fa6-brands:${os}` ``) is invisible to
+  the scan, so it is never bundled; `@iconify/vue` then falls back to fetching it from the public
+  Iconify API at runtime. Resolve to literals instead — see `FAnalysisBuildStep.vue`.
+- **A path that stops matching fails silently** — an empty icon slot, not a build error.
+  `apps/client-ui/test/unit/icon-bundle.spec.ts` pins one uniquely-attributable icon per scanned
+  source to catch that.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
                 "@ilingo/validup": "^1.1.0",
                 "@ilingo/validup-vue": "^1.1.0",
                 "@ilingo/vue": "^6.1.0",
+                "@nuxt/icon": "^2.4.1",
                 "@nuxtjs/google-fonts": "^3.2.0",
                 "@pinia/nuxt": "^1.0.1",
                 "@privateaim/client-vue": "^0.13.0",
@@ -90,6 +91,7 @@
                 "smob": "^1.6.2",
                 "tailwindcss": "^4.3.3",
                 "validup": "^1.0.0",
+                "vitest": "^4.1.10",
                 "vue": "^3.5.40",
                 "vue-tsc": "^3.3.8",
                 "zod": "^4.4.3"
@@ -3000,12 +3002,34 @@
                 "@iconify/types": "*"
             }
         },
+        "node_modules/@iconify/collections": {
+            "version": "1.0.717",
+            "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.717.tgz",
+            "integrity": "sha512-SMPMge2pQwM+/mAVoBMwLl6jfEaZP2qGRAj8jhucG9qzqEW1shtV6dFTE/t0Kin8+7+RcQrr4vIddW3m7fR24w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@iconify/types": "*"
+            }
+        },
         "node_modules/@iconify/types": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
             "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
             "devOptional": true,
             "license": "MIT"
+        },
+        "node_modules/@iconify/utils": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+            "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@antfu/install-pkg": "^1.1.0",
+                "@iconify/types": "^2.0.0",
+                "import-meta-resolve": "^4.2.0"
+            }
         },
         "node_modules/@iconify/vue": {
             "version": "5.0.1",
@@ -4145,26 +4169,6 @@
                 }
             }
         },
-        "node_modules/@nuxt/cli/node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@nuxt/cli/node_modules/commander": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-            "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=22.12.0"
-            }
-        },
         "node_modules/@nuxt/cli/node_modules/jiti": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4336,6 +4340,36 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/@nuxt/icon": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-2.4.1.tgz",
+            "integrity": "sha512-fOY3kiT6OoL4bWXVmMLc1VgoCm1PxIGSBmsSaLO090NEgtd1ub441dZ7MEoOD5UIilWzba1kCWdwJcAkGCOwLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@iconify/collections": "^1.0.715",
+                "@iconify/types": "^2.0.0",
+                "@iconify/utils": "^3.1.4",
+                "@iconify/vue": "^5.0.1",
+                "@nuxt/devtools-kit": "^3.3.1",
+                "@nuxt/kit": "^4.5.0",
+                "consola": "^3.4.2",
+                "local-pkg": "^1.2.1",
+                "mlly": "^1.8.2",
+                "ohash": "^2.0.11",
+                "picomatch": "^4.0.5",
+                "std-env": "^4.2.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@nuxt/kit": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
@@ -4412,61 +4446,6 @@
                     "optional": true
                 },
                 "unplugin": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@nuxt/kit/node_modules/unplugin": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
-            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "picomatch": "^4.0.4",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "peerDependencies": {
-                "@farmfe/core": "*",
-                "@rspack/core": "*",
-                "bun-types-no-globals": "*",
-                "esbuild": "*",
-                "rolldown": "*",
-                "rollup": "*",
-                "unloader": "*",
-                "vite": "*",
-                "webpack": "*"
-            },
-            "peerDependenciesMeta": {
-                "@farmfe/core": {
-                    "optional": true
-                },
-                "@rspack/core": {
-                    "optional": true
-                },
-                "bun-types-no-globals": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "rolldown": {
-                    "optional": true
-                },
-                "rollup": {
-                    "optional": true
-                },
-                "unloader": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                },
-                "webpack": {
                     "optional": true
                 }
             }
@@ -4584,61 +4563,6 @@
                     "optional": true
                 },
                 "unplugin": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@nuxt/nitro-server/node_modules/unplugin": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
-            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/remapping": "^2.3.5",
-                "picomatch": "^4.0.4",
-                "webpack-virtual-modules": "^0.6.2"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "peerDependencies": {
-                "@farmfe/core": "*",
-                "@rspack/core": "*",
-                "bun-types-no-globals": "*",
-                "esbuild": "*",
-                "rolldown": "*",
-                "rollup": "*",
-                "unloader": "*",
-                "vite": "*",
-                "webpack": "*"
-            },
-            "peerDependenciesMeta": {
-                "@farmfe/core": {
-                    "optional": true
-                },
-                "@rspack/core": {
-                    "optional": true
-                },
-                "bun-types-no-globals": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "rolldown": {
-                    "optional": true
-                },
-                "rollup": {
-                    "optional": true
-                },
-                "unloader": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                },
-                "webpack": {
                     "optional": true
                 }
             }
@@ -8316,13 +8240,6 @@
                 "assertion-error": "^2.0.1"
             }
         },
-        "node_modules/@types/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-            "extraneous": true,
-            "license": "MIT"
-        },
         "node_modules/@types/cors": {
             "version": "2.8.19",
             "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -11200,26 +11117,11 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "node_modules/better-sqlite3": {
-            "version": "12.11.1",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-            "extraneous": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "prebuild-install": "^7.1.1"
-            },
-            "engines": {
-                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-            }
-        },
         "node_modules/bindings": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
@@ -12610,22 +12512,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/dedent": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -12638,16 +12524,6 @@
                 "babel-plugin-macros": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -12779,7 +12655,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
@@ -14070,16 +13946,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "extraneous": true,
-            "license": "(MIT OR WTFPL)",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/expect-type": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -14324,7 +14190,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fill-range": {
@@ -14747,13 +14613,6 @@
             "engines": {
                 "node": ">=18"
             }
-        },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "extraneous": true,
-            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "13.0.6",
@@ -15257,7 +15116,6 @@
             "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -16976,19 +16834,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/minimatch": {
             "version": "10.2.6",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -17009,7 +16854,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -17224,13 +17069,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/napi-build-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-            "extraneous": true,
-            "license": "MIT"
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17409,19 +17247,6 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/node-abi": {
-            "version": "3.94.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-            "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/node-addon-api": {
@@ -19352,54 +19177,6 @@
                 }
             }
         },
-        "node_modules/prebuild-install": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^2.0.0",
-                "node-abi": "^3.3.0",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^4.0.0",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/prebuild-install/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "extraneous": true,
-            "license": "ISC"
-        },
-        "node_modules/prebuild-install/node_modules/tar-fs": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
-            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -19703,29 +19480,6 @@
                 "ebec": "^1.1.0",
                 "smob": "^1.4.0"
             }
-        },
-        "node_modules/rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "extraneous": true,
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "node_modules/rc/node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "extraneous": true,
-            "license": "ISC"
         },
         "node_modules/rc9": {
             "version": "3.0.1",
@@ -20577,7 +20331,7 @@
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
             "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -20835,53 +20589,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "extraneous": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-            "extraneous": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "decompress-response": "^6.0.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
         },
         "node_modules/simple-git": {
             "version": "3.36.0",
@@ -21386,16 +21093,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/strip-literal": {
@@ -22029,19 +21726,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
-        },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
@@ -24169,17 +23853,6 @@
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/vitepress/node_modules/universal-cookie": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
-            "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/cookie": "^0.6.0",
-                "cookie": "^0.7.2"
-            }
         },
         "node_modules/vitepress/node_modules/vite": {
             "version": "5.4.21",

--- a/packages/client-vue/src/components/analysis/steps/FAnalysisBuildStep.vue
+++ b/packages/client-vue/src/components/analysis/steps/FAnalysisBuildStep.vue
@@ -63,12 +63,35 @@ export default defineComponent({
             return null;
         });
 
+        // `buildOs` is docker's image `Os`, i.e. a GOOS value. Resolve it to a
+        // literal icon name rather than interpolating one: build-time icon
+        // scanners (see the `NuxtIconBundle` plugin in client-ui's
+        // nuxt.config.ts) only ever see literals, so a composed name is never
+        // bundled and renders an empty slot. `darwin` has no brand icon of its
+        // own, and any unmapped value now yields no icon at all instead of a
+        // request for one that does not exist.
+        const buildOsIcon = computed(() => {
+            switch (props.entity.buildOs) {
+                case 'linux':
+                    return 'fa6-brands:linux';
+                case 'windows':
+                    return 'fa6-brands:windows';
+                case 'darwin':
+                    return 'fa6-brands:apple';
+                case 'freebsd':
+                    return 'fa6-brands:freebsd';
+                default:
+                    return null;
+            }
+        });
+
         return {
             progress,
             handleUpdated,
             handleFailed,
             handleExecuted,
             size,
+            buildOsIcon,
             resolveTextColorClass,
         };
     },
@@ -157,7 +180,10 @@ export default defineComponent({
                                     </div>
                                     <div>
                                         {{ entity.buildOs }}
-                                        <VCIcon :name="'fa6-brands:' + entity.buildOs" />
+                                        <VCIcon
+                                            v-if="buildOsIcon"
+                                            :name="buildOsIcon"
+                                        />
                                     </div>
                                 </div>
                                 <div


### PR DESCRIPTION
Closes #1811.

`plugins/vuecs.ts` registered both full Font Awesome 6 collections at module scope — 1,902 icons, roughly 429 KB gzip, for the 115 the app actually renders — on every page load.

It now runs [`@nuxt/icon`'s standalone vite plugin](https://github.com/nuxt/icon), which scans source for `<collection>:<name>` literals and emits the found subset into `virtual:nuxt-icon-bundle/register`. That module registers through `addIcon` from `@iconify/vue`, the same global store `<VCIcon>` resolves against, so **no component changed**.

Ported from authup/authup#3365.

## Measured

Client JS, `.output/public/_nuxt/*.js`, clean build:

| | raw | gzip |
|---|---|---|
| before | 3433 KB | **1031 KB** |
| after | 2180 KB | **625 KB** |
| saved | 1253 KB | **406 KB (39%)** |

115 icons bundled, 65 KB uncompressed.

## The glob list is load-bearing

It fails silently: a path that stops matching yields an empty icon slot, not a build error. Besides this app's own tree it must cover

- `@privateaim/client-vue` — aliased to `src` in `nuxt.config.ts`, so its source is what gets compiled in,
- `@authup/client-web-kit` — its components and identity-provider preset tables hold ~50 names,
- `@vuecs/icons-font-awesome` — the vuecs behavioral defaults (pagination arrows, submit-button, alert icons, collapse chevrons), whose names appear in no hub source file.

Those two `node_modules` paths also force `globExclude: []`, since the plugin default ignores `node_modules` and `dist`. `.ts` is added to the scanned extensions because plenty of names live in plain TS modules. A repo-wide grep confirmed those are the *only* two packages in `node_modules` carrying icon literals. `@privateaim/client-vue-theme` carries none today and is listed only so a theme that later ships icon defaults works without a change here.

## The guard

The plugin options live in `apps/client-ui/icon-bundle.config.ts` rather than inline in `nuxt.config.ts` so `test/unit/icon-bundle.spec.ts` can drive the real plugin with the real globs, pinning one uniquely-attributable icon per scanned source. Deleting any one glob fails exactly one assertion and nothing else — verified.

It asserts the plugin's own `load('\0virtual:nuxt-icon-bundle')` output rather than a built bundle, which matters here: CI's build cache carries only `**/dist/**` and `.nx`, so `apps/client-ui/.output` does not survive into the test job, and a spec reading it would have been broken or needed extra cache plumbing. Asserting a rendered page cannot work at all — `@iconify/vue` resolves icons client-side, so SSR output carries empty `<svg>` shells either way. Runs in ~150 ms with no build.

This is client-ui's first vitest suite. Note `nuxi typecheck` covers `test/**` here under Nuxt 4 strict, unlike every other workspace (whose `tsconfig.build.json` includes `src/**` only).

## One fix this forced

A scan only sees literals, so `FAnalysisBuildStep`'s `:name="'fa6-brands:' + entity.buildOs"` would have gone unbundled and fallen back to a runtime fetch from the public Iconify API. It resolves through a computed switch now, matching the existing `FProcessStatus` pattern. That also drops a pre-existing miss: `darwin` has no brand icon of its own and now maps to `fa6-brands:apple`.

`packages/client-vue` is published, so this rule applies to it independently of this app — a consuming app's scanner sees exactly the same literals. Documented in `docs/src/reference/frontend/client-vue.md` and `.agents/conventions.md`.

## Notes

- The issue's "296 referenced icons" is an occurrence count, not distinct. Repo source has 94 distinct names; 115 once the authup kit's 50 and the vuecs preset's 11 are included. The ~85%-waste conclusion holds either way.
- `package-lock.json` carries an unrelated prune from `npm install`: a stale root `better-sqlite3@12.11.1` entry already flagged `"extraneous": true`, plus its `prebuild-install` chain and a few nested dupes. All four apps still resolve `better-sqlite3@13.0.2` (`npm ls` verified).

## Verification

- clean `nuxi build`, sizes above
- `nuxi typecheck` clean
- `eslint` clean
- `client-ui` 5/5, `client-vue` 16/16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build-time icon bundling for client UI and Vue components.
  * Added operating-system icons for Linux, Windows, macOS, and FreeBSD build metadata.
  * Unrecognized operating systems now display without an icon.
* **Bug Fixes**
  * Prevented unrelated Font Awesome icons from being included in the client bundle, reducing payload size.
* **Documentation**
  * Documented supported icon collections, literal icon-name requirements, and troubleshooting guidance.
* **Tests**
  * Added coverage validating bundled and excluded icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->